### PR TITLE
Update build.yml with new deploy hook following Cloudflare account move

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,4 +7,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run:
-          curl -X POST "https://api.cloudflare.com/client/v4/pages/webhooks/deploy_hooks/1aaca29c-199a-4a3b-b9e9-06c497746397"
+          curl -X POST "https://api.cloudflare.com/client/v4/pages/webhooks/deploy_hooks/fe5b4ebb-7029-4c5a-8cd7-4b933dd7bdc0"


### PR DESCRIPTION
## Description

- We moved from GI to GFSC cloudflare host
- The cron that runs every 3 hours relies on a deploy hook
