### PR TITLE
feat: Filter by date and region on index, events and partner pages

### DIFF
--- a/app/Route/Events.elm
+++ b/app/Route/Events.elm
@@ -31,7 +31,6 @@ import View exposing (View)
 type alias Model =
     { filterByDate : Theme.Paginator.Filter
     , filterByRegion : Int
-    , visibleEvents : List Data.PlaceCal.Events.Event
     , nowTime : Time.Posix
     , viewportWidth : Float
     }
@@ -52,7 +51,6 @@ init :
 init app _ =
     ( { filterByDate = Theme.Paginator.None
       , filterByRegion = 0
-      , visibleEvents = Data.PlaceCal.Events.eventsWithPartners app.sharedData.events app.sharedData.partners
       , nowTime = Time.millisToPosix 0
       , viewportWidth = 320
       }
@@ -75,9 +73,8 @@ update app _ msg model =
             case submsg of
                 Theme.Paginator.ClickedDay posix ->
                     ( { model
-                        | filterByDate = Theme.Paginator.Day posix
-                        , visibleEvents =
-                            Data.PlaceCal.Events.eventsWithPartners (Data.PlaceCal.Events.eventsFromDate app.sharedData.events posix) app.sharedData.partners
+                        | filterByDate =
+                            Theme.Paginator.Day posix
                       }
                     , Effect.none
                     )
@@ -85,7 +82,6 @@ update app _ msg model =
                 Theme.Paginator.ClickedAllPastEvents ->
                     ( { model
                         | filterByDate = Theme.Paginator.Past
-                        , visibleEvents = Data.PlaceCal.Events.eventsWithPartners (List.reverse (Data.PlaceCal.Events.onOrBeforeDate app.sharedData.events model.nowTime)) app.sharedData.partners
                       }
                     , Effect.none
                     )
@@ -93,7 +89,6 @@ update app _ msg model =
                 Theme.Paginator.ClickedAllFutureEvents ->
                     ( { model
                         | filterByDate = Theme.Paginator.Future
-                        , visibleEvents = Data.PlaceCal.Events.eventsWithPartners (Data.PlaceCal.Events.afterDate app.sharedData.events model.nowTime) app.sharedData.partners
                       }
                     , Effect.none
                     )
@@ -102,8 +97,6 @@ update app _ msg model =
                     ( { model
                         | filterByDate = Theme.Paginator.Day newTime
                         , nowTime = newTime
-                        , visibleEvents =
-                            Data.PlaceCal.Events.eventsWithPartners (Data.PlaceCal.Events.eventsFromDate app.sharedData.events newTime) app.sharedData.partners
                       }
                     , Effect.none
                     )
@@ -135,7 +128,6 @@ update app _ msg model =
                 Theme.RegionSelector.ClickedSelector regionId ->
                     ( { model
                         | filterByRegion = regionId
-                        , visibleEvents = Data.PlaceCal.Events.eventsFromRegionId model.visibleEvents regionId
                       }
                     , Effect.none
                     )
@@ -185,7 +177,7 @@ view :
     -> Shared.Model
     -> Model
     -> View (PagesMsg.PagesMsg Msg)
-view _ _ model =
+view app _ model =
     { title = t (PageMetaTitle (t EventsTitle))
     , body =
         [ Theme.PageTemplate.view
@@ -193,7 +185,7 @@ view _ _ model =
             , title = t EventsTitle
             , bigText = { text = t EventsSummary, node = "h3" }
             , smallText = Nothing
-            , innerContent = Just (Theme.Page.Events.viewEvents model)
+            , innerContent = Just (Theme.Page.Events.viewEvents (Data.PlaceCal.Events.eventsWithPartners app.sharedData.events app.sharedData.partners) model)
             , outerContent = Nothing
             }
             |> Html.Styled.map PagesMsg.fromMsg

--- a/app/Route/Index.elm
+++ b/app/Route/Index.elm
@@ -9,34 +9,76 @@ module Route.Index exposing (Model, Msg, RouteParams, route, Data, ActionData)
 import BackendTask
 import Copy.Keys exposing (Key(..))
 import Copy.Text exposing (t)
+import Effect
 import FatalError
 import Head
+import Html.Styled
 import PagesMsg
 import RouteBuilder
 import Shared
+import Task
 import Theme.Page.Index
 import Theme.PageTemplate
+import Theme.RegionSelector exposing (Msg(..))
+import UrlPath
 import View
 
 
 type alias Model =
-    {}
+    { filterBy : Int
+    }
 
 
 type alias Msg =
-    ()
+    Theme.RegionSelector.Msg
 
 
 type alias RouteParams =
     {}
 
 
-route : RouteBuilder.StatelessRoute RouteParams Data ActionData
+init :
+    RouteBuilder.App Data ActionData RouteParams
+    -> Shared.Model
+    -> ( Model, Effect.Effect Msg )
+init app _ =
+    ( { filterBy = 0
+      }
+    , Effect.none
+    )
+
+
+update :
+    RouteBuilder.App Data ActionData RouteParams
+    -> Shared.Model
+    -> Msg
+    -> Model
+    -> ( Model, Effect.Effect Msg )
+update app _ msg model =
+    case msg of
+        ClickedSelector tagId ->
+            ( { model
+                | filterBy = tagId
+              }
+            , Effect.none
+            )
+
+
+subscriptions : RouteParams -> UrlPath.UrlPath -> Shared.Model -> Model -> Sub Msg
+subscriptions _ _ _ _ =
+    Sub.none
+
+
+route : RouteBuilder.StatefulRoute RouteParams Data ActionData Model Msg
 route =
     RouteBuilder.single
         { data = data, head = head }
-        |> RouteBuilder.buildNoState
-            { view = view }
+        |> RouteBuilder.buildWithLocalState
+            { init = init
+            , view = view
+            , update = update
+            , subscriptions = subscriptions
+            }
 
 
 type alias Data =
@@ -64,8 +106,12 @@ head _ =
 view :
     RouteBuilder.App Data ActionData RouteParams
     -> Shared.Model
+    -> Model
     -> View.View (PagesMsg.PagesMsg Msg)
-view app _ =
+view app _ model =
     { title = t SiteTitle
-    , body = [ Theme.Page.Index.view app.sharedData ]
+    , body =
+        [ Theme.Page.Index.view app.sharedData model.filterBy
+            |> Html.Styled.map PagesMsg.fromMsg
+        ]
     }

--- a/app/Route/Index.elm
+++ b/app/Route/Index.elm
@@ -25,7 +25,7 @@ import View
 
 
 type alias Model =
-    { filterBy : Int
+    { filterByRegion : Int
     }
 
 
@@ -42,7 +42,7 @@ init :
     -> Shared.Model
     -> ( Model, Effect.Effect Msg )
 init app _ =
-    ( { filterBy = 0
+    ( { filterByRegion = 0
       }
     , Effect.none
     )
@@ -58,7 +58,7 @@ update app _ msg model =
     case msg of
         ClickedSelector tagId ->
             ( { model
-                | filterBy = tagId
+                | filterByRegion = tagId
               }
             , Effect.none
             )
@@ -111,7 +111,7 @@ view :
 view app _ model =
     { title = t SiteTitle
     , body =
-        [ Theme.Page.Index.view app.sharedData model.filterBy
+        [ Theme.Page.Index.view app.sharedData model.filterByRegion
             |> Html.Styled.map PagesMsg.fromMsg
         ]
     }

--- a/app/Route/Index.elm
+++ b/app/Route/Index.elm
@@ -20,12 +20,14 @@ import Task
 import Theme.Page.Index
 import Theme.PageTemplate
 import Theme.RegionSelector exposing (Msg(..))
+import Time
 import UrlPath
 import View
 
 
 type alias Model =
     { filterByRegion : Int
+    , nowTime : Time.Posix
     }
 
 
@@ -43,6 +45,7 @@ init :
     -> ( Model, Effect.Effect Msg )
 init app _ =
     ( { filterByRegion = 0
+      , nowTime = app.sharedData.time
       }
     , Effect.none
     )
@@ -111,7 +114,7 @@ view :
 view app _ model =
     { title = t SiteTitle
     , body =
-        [ Theme.Page.Index.view app.sharedData model.filterByRegion
+        [ Theme.Page.Index.view app.sharedData model
             |> Html.Styled.map PagesMsg.fromMsg
         ]
     }

--- a/app/Route/Partners/Partner_.elm
+++ b/app/Route/Partners/Partner_.elm
@@ -31,7 +31,8 @@ import View
 
 
 type alias Model =
-    { filterBy : Theme.Paginator.Filter
+    { filterByDate : Theme.Paginator.Filter
+    , filterByRegion : Int
     , visibleEvents : List Data.PlaceCal.Events.Event
     , nowTime : Time.Posix
     , viewportWidth : Float
@@ -80,7 +81,8 @@ init app _ =
                 |> Effect.fromCmd
             ]
     in
-    ( { filterBy = Theme.Paginator.None
+    ( { filterByDate = Theme.Paginator.None
+      , filterByRegion = 0
       , visibleEvents = app.sharedData.events
       , nowTime = Time.millisToPosix 0
       , viewportWidth = 320
@@ -116,7 +118,7 @@ update app _ msg model =
     case msg of
         ClickedDay posix ->
             ( { model
-                | filterBy = Theme.Paginator.Day posix
+                | filterByDate = Theme.Paginator.Day posix
                 , visibleEvents =
                     eventsFromPartnerId aPartner.id (Data.PlaceCal.Events.eventsFromDate app.sharedData.events posix)
               }
@@ -125,7 +127,7 @@ update app _ msg model =
 
         ClickedAllPastEvents ->
             ( { model
-                | filterBy = Theme.Paginator.Past
+                | filterByDate = Theme.Paginator.Past
                 , visibleEvents = eventsFromPartnerId aPartner.id (List.reverse (Data.PlaceCal.Events.onOrBeforeDate app.sharedData.events model.nowTime))
               }
             , Effect.none
@@ -133,7 +135,7 @@ update app _ msg model =
 
         ClickedAllFutureEvents ->
             ( { model
-                | filterBy = Theme.Paginator.Future
+                | filterByDate = Theme.Paginator.Future
                 , visibleEvents = eventsFromPartnerId aPartner.id (Data.PlaceCal.Events.afterDate app.sharedData.events model.nowTime)
               }
             , Effect.none
@@ -141,7 +143,7 @@ update app _ msg model =
 
         GetTime newTime ->
             ( { model
-                | filterBy = Theme.Paginator.Day newTime
+                | filterByDate = Theme.Paginator.Day newTime
                 , nowTime = newTime
                 , visibleEvents =
                     eventsFromPartnerId aPartner.id (Data.PlaceCal.Events.eventsFromDate app.sharedData.events newTime)

--- a/app/Route/Partners/Partner_.elm
+++ b/app/Route/Partners/Partner_.elm
@@ -22,6 +22,7 @@ import RouteBuilder
 import Shared
 import Task
 import Theme.Global
+import Theme.Page.Events
 import Theme.Page.Partner
 import Theme.PageTemplate
 import Theme.Paginator exposing (Msg(..))
@@ -41,7 +42,7 @@ type alias Model =
 
 
 type alias Msg =
-    Theme.Paginator.Msg
+    Theme.Page.Events.Msg
 
 
 type alias RouteParams =
@@ -76,8 +77,10 @@ init app _ =
         tasks : List (Effect.Effect Msg)
         tasks =
             [ Task.perform GetTime Time.now
+                |> Cmd.map Theme.Page.Events.fromPaginatorMsg
                 |> Effect.fromCmd
             , Task.perform GotViewport Browser.Dom.getViewport
+                |> Cmd.map Theme.Page.Events.fromPaginatorMsg
                 |> Effect.fromCmd
             ]
     in
@@ -95,6 +98,7 @@ init app _ =
                     ++ [ Browser.Dom.getElement fragment
                             |> Task.andThen (\element -> Browser.Dom.setViewport 0 element.element.y)
                             |> Task.attempt (\_ -> NoOp)
+                            |> Cmd.map Theme.Page.Events.fromPaginatorMsg
                             |> Effect.fromCmd
                        ]
 
@@ -116,59 +120,68 @@ update app _ msg model =
             Data.PlaceCal.Partners.partnerFromSlug app.sharedData.partners app.routeParams.partner
     in
     case msg of
-        ClickedDay posix ->
-            ( { model
-                | filterByDate = Theme.Paginator.Day posix
-                , visibleEvents =
-                    eventsFromPartnerId aPartner.id (Data.PlaceCal.Events.eventsFromDate app.sharedData.events posix)
-              }
-            , Effect.none
-            )
+        Theme.Page.Events.PaginatorMsg submsg ->
+            case submsg of
+                Theme.Paginator.ClickedDay posix ->
+                    ( { model
+                        | filterByDate = Theme.Paginator.Day posix
+                        , visibleEvents =
+                            eventsFromPartnerId aPartner.id (Data.PlaceCal.Events.eventsFromDate app.sharedData.events posix)
+                      }
+                    , Effect.none
+                    )
 
-        ClickedAllPastEvents ->
-            ( { model
-                | filterByDate = Theme.Paginator.Past
-                , visibleEvents = eventsFromPartnerId aPartner.id (List.reverse (Data.PlaceCal.Events.onOrBeforeDate app.sharedData.events model.nowTime))
-              }
-            , Effect.none
-            )
+                Theme.Paginator.ClickedAllPastEvents ->
+                    ( { model
+                        | filterByDate = Theme.Paginator.Past
+                        , visibleEvents = eventsFromPartnerId aPartner.id (List.reverse (Data.PlaceCal.Events.onOrBeforeDate app.sharedData.events model.nowTime))
+                      }
+                    , Effect.none
+                    )
 
-        ClickedAllFutureEvents ->
-            ( { model
-                | filterByDate = Theme.Paginator.Future
-                , visibleEvents = eventsFromPartnerId aPartner.id (Data.PlaceCal.Events.afterDate app.sharedData.events model.nowTime)
-              }
-            , Effect.none
-            )
+                Theme.Paginator.ClickedAllFutureEvents ->
+                    ( { model
+                        | filterByDate = Theme.Paginator.Future
+                        , visibleEvents = eventsFromPartnerId aPartner.id (Data.PlaceCal.Events.afterDate app.sharedData.events model.nowTime)
+                      }
+                    , Effect.none
+                    )
 
-        GetTime newTime ->
-            ( { model
-                | filterByDate = Theme.Paginator.Day newTime
-                , nowTime = newTime
-                , visibleEvents =
-                    eventsFromPartnerId aPartner.id (Data.PlaceCal.Events.eventsFromDate app.sharedData.events newTime)
-              }
-            , Effect.none
-            )
+                Theme.Paginator.GetTime newTime ->
+                    ( { model
+                        | filterByDate = Theme.Paginator.Day newTime
+                        , nowTime = newTime
+                        , visibleEvents =
+                            eventsFromPartnerId aPartner.id (Data.PlaceCal.Events.eventsFromDate app.sharedData.events newTime)
+                      }
+                    , Effect.none
+                    )
 
-        ScrollRight ->
-            ( model
-            , Task.attempt (\_ -> NoOp)
-                (Theme.Paginator.scrollPagination Theme.Paginator.Right model.viewportWidth)
-                |> Effect.fromCmd
-            )
+                Theme.Paginator.ScrollRight ->
+                    ( model
+                    , Task.attempt (\_ -> NoOp)
+                        (Theme.Paginator.scrollPagination Theme.Paginator.Right model.viewportWidth)
+                        |> Cmd.map Theme.Page.Events.fromPaginatorMsg
+                        |> Effect.fromCmd
+                    )
 
-        ScrollLeft ->
-            ( model
-            , Task.attempt (\_ -> NoOp)
-                (Theme.Paginator.scrollPagination Theme.Paginator.Left model.viewportWidth)
-                |> Effect.fromCmd
-            )
+                Theme.Paginator.ScrollLeft ->
+                    ( model
+                    , Task.attempt (\_ -> NoOp)
+                        (Theme.Paginator.scrollPagination Theme.Paginator.Left model.viewportWidth)
+                        |> Cmd.map Theme.Page.Events.fromPaginatorMsg
+                        |> Effect.fromCmd
+                    )
 
-        GotViewport viewport ->
-            ( { model | viewportWidth = Maybe.withDefault model.viewportWidth (Just viewport.scene.width) }, Effect.none )
+                Theme.Paginator.GotViewport viewport ->
+                    ( { model | viewportWidth = Maybe.withDefault model.viewportWidth (Just viewport.scene.width) }, Effect.none )
 
-        NoOp ->
+                Theme.Paginator.NoOp ->
+                    ( model, Effect.none )
+
+        Theme.Page.Events.RegionSelectorMsg _ ->
+            -- We do not include Region Selector on individual Partner pages
+            -- But may  in future if some partners have events in multiple regions
             ( model, Effect.none )
 
 

--- a/src/Copy/Keys.elm
+++ b/src/Copy/Keys.elm
@@ -42,6 +42,8 @@ type Key
     | FooterCredit3Link
     | FooterCopyright String
     | FooterPlaceCal
+      --- Region Selector
+    | AllRegionSelectorLabel
       --- Index Page
     | IndexTitle
     | IndexMetaDescription

--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -131,6 +131,10 @@ t key =
         FooterPlaceCal ->
             "Powered by PlaceCal"
 
+        --- Region Selector
+        AllRegionSelectorLabel ->
+            "Everywhere"
+
         --- Index Page
         IndexTitle ->
             "Home"

--- a/src/Data/PlaceCal/Events.elm
+++ b/src/Data/PlaceCal/Events.elm
@@ -128,7 +128,7 @@ afterDate eventList fromDate =
 
 nextNEvents : Int -> List Event -> Time.Posix -> List Event
 nextNEvents showCount eventList fromTime =
-    List.take showCount (eventsFromDate eventList fromTime)
+    List.take showCount (afterDate eventList fromTime)
 
 
 eventPartnerFromId : List Data.PlaceCal.Partners.Partner -> String -> EventPartner

--- a/src/Data/PlaceCal/Events.elm
+++ b/src/Data/PlaceCal/Events.elm
@@ -173,7 +173,15 @@ eventsData =
         )
         |> BackendTask.map (List.map .allEvents)
         |> BackendTask.map List.concat
+        |> BackendTask.map sortEventsByDate
         |> BackendTask.map (\eventList -> { allEvents = eventList })
+
+
+sortEventsByDate : List Event -> List Event
+sortEventsByDate events =
+    List.sortBy
+        (\event -> Time.posixToMillis event.startDatetime)
+        events
 
 
 allEventsQuery : String -> Json.Encode.Value

--- a/src/Data/PlaceCal/Partners.elm
+++ b/src/Data/PlaceCal/Partners.elm
@@ -1,4 +1,4 @@
-module Data.PlaceCal.Partners exposing (Address, Contact, Partner, ServiceArea, partnerFromSlug, partnerNamesFromIds, partnersData, partnershipTagIdList)
+module Data.PlaceCal.Partners exposing (Address, Contact, Partner, ServiceArea, partnerFromSlug, partnerNamesFromIds, partnersData, partnershipTagIdList, partnershipTagList)
 
 import BackendTask
 import BackendTask.Custom
@@ -169,7 +169,7 @@ decodePartner : Int -> Json.Decode.Decoder Partner
 decodePartner partnershipTagInt =
     Json.Decode.succeed Partner
         |> Json.Decode.Pipeline.required "id" Json.Decode.string
-        |> Json.Decode.Pipeline.optional "partnershipTagId" (Json.Decode.succeed partnershipTagInt) 0
+        |> Json.Decode.Pipeline.optional "partnershipTagId" (Json.Decode.succeed partnershipTagInt) partnershipTagInt
         |> Json.Decode.Pipeline.required "name" Json.Decode.string
         |> Json.Decode.Pipeline.optional "summary" Json.Decode.string ""
         |> Json.Decode.Pipeline.optional "description" Json.Decode.string ""

--- a/src/Theme/Page/Events.elm
+++ b/src/Theme/Page/Events.elm
@@ -17,7 +17,8 @@ import Time
 
 viewEvents :
     { localModel
-        | filterBy : Theme.Paginator.Filter
+        | filterByDate : Theme.Paginator.Filter
+        , filterByRegion : Int
         , nowTime : Time.Posix
         , visibleEvents : List Data.PlaceCal.Events.Event
     }
@@ -25,7 +26,7 @@ viewEvents :
 viewEvents model =
     section [ css [ eventsContainerStyle ] ]
         [ Theme.Paginator.viewPagination model
-        , viewFilteredEventsList model.filterBy model.visibleEvents
+        , viewFilteredEventsList model.filterByDate model.visibleEvents
         ]
 
 

--- a/src/Theme/Page/Events.elm
+++ b/src/Theme/Page/Events.elm
@@ -1,4 +1,4 @@
-module Theme.Page.Events exposing (viewEvents, viewEventsList)
+module Theme.Page.Events exposing (Msg(..), fromPaginatorMsg, fromRegionSelectorMsg, viewEvents, viewEventsList)
 
 import Copy.Keys exposing (Key(..))
 import Copy.Text exposing (t)
@@ -12,7 +12,23 @@ import Html.Styled exposing (Html, a, article, div, h4, li, p, section, span, te
 import Html.Styled.Attributes exposing (css, href)
 import Theme.Global exposing (borderTransition, colorTransition, introTextLargeStyle, pink, white, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 import Theme.Paginator
+import Theme.RegionSelector
 import Time
+
+
+type Msg
+    = PaginatorMsg Theme.Paginator.Msg
+    | RegionSelectorMsg Theme.RegionSelector.Msg
+
+
+fromPaginatorMsg : Theme.Paginator.Msg -> Msg
+fromPaginatorMsg msg =
+    PaginatorMsg msg
+
+
+fromRegionSelectorMsg : Theme.RegionSelector.Msg -> Msg
+fromRegionSelectorMsg msg =
+    RegionSelectorMsg msg
 
 
 viewEvents :
@@ -22,11 +38,12 @@ viewEvents :
         , nowTime : Time.Posix
         , visibleEvents : List Data.PlaceCal.Events.Event
     }
-    -> Html Theme.Paginator.Msg
+    -> Html Msg
 viewEvents model =
     section [ css [ eventsContainerStyle ] ]
-        [ Theme.Paginator.viewPagination model
-        , viewFilteredEventsList model.filterByDate model.visibleEvents
+        [ Theme.RegionSelector.viewRegionSelector { filterBy = model.filterByRegion } |> Html.Styled.map fromRegionSelectorMsg
+        , Theme.Paginator.viewPagination model |> Html.Styled.map fromPaginatorMsg
+        , viewFilteredEventsList model.filterByDate model.visibleEvents |> Html.Styled.map fromPaginatorMsg
         ]
 
 

--- a/src/Theme/Page/Index.elm
+++ b/src/Theme/Page/Index.elm
@@ -12,14 +12,15 @@ import Shared
 import Theme.Global
 import Theme.Page.Events
 import Theme.Page.News
+import Theme.RegionSelector
 import Time
 
 
-view : Shared.Data -> Html msg
-view sharedData =
+view : Shared.Data -> Int -> Html Theme.RegionSelector.Msg
+view sharedData filterByRegionId =
     div [ css [ pageWrapperStyle ] ]
         [ viewIntro (t IndexIntroTitle) (t IndexIntroMessage) (t IndexIntroButtonText)
-        , viewFeatured sharedData.time (Data.PlaceCal.Events.eventsWithPartners sharedData.events sharedData.partners)
+        , viewFeatured sharedData.time (Data.PlaceCal.Events.eventsWithPartners sharedData.events sharedData.partners) filterByRegionId
         , viewLatestNews (List.head sharedData.articles) (t IndexNewsHeader) (t IndexNewsButtonText)
         ]
 
@@ -47,11 +48,12 @@ viewIntro introTitle introMsg eventButtonText =
         ]
 
 
-viewFeatured : Time.Posix -> List Data.PlaceCal.Events.Event -> Html msg
-viewFeatured fromTime eventList =
+viewFeatured : Time.Posix -> List Data.PlaceCal.Events.Event -> Int -> Html Theme.RegionSelector.Msg
+viewFeatured fromTime eventList regionId =
     section [ css [ sectionStyle, Theme.Global.darkBlueBackgroundStyle, eventsSectionStyle ] ]
         [ h2 [ css [ Theme.Global.smallFloatingTitleStyle ] ] [ text (t IndexFeaturedHeader) ]
-        , Theme.Page.Events.viewEventsList (Data.PlaceCal.Events.next4Events eventList fromTime)
+        , Theme.RegionSelector.viewRegionSelector { filterBy = regionId }
+        , Theme.Page.Events.viewEventsList (Data.PlaceCal.Events.nextNEvents 8 (Data.PlaceCal.Events.eventsFromRegionId eventList regionId) fromTime)
         , p [ css [ Theme.Global.buttonFloatingWrapperStyle, width (calc (pct 100) minus (rem 2)) ] ]
             [ a
                 [ href (Helpers.TransRoutes.toAbsoluteUrl Helpers.TransRoutes.Events)

--- a/src/Theme/Page/Index.elm
+++ b/src/Theme/Page/Index.elm
@@ -17,11 +17,18 @@ import Theme.RegionSelector
 import Time
 
 
-view : Shared.Data -> Int -> Html Theme.RegionSelector.Msg
-view sharedData filterByRegionId =
+view :
+    Shared.Data
+    ->
+        { localModel
+            | filterByRegion : Int
+            , nowTime : Time.Posix
+        }
+    -> Html Theme.RegionSelector.Msg
+view sharedData localModel =
     div [ css [ pageWrapperStyle ] ]
         [ viewIntro (t IndexIntroTitle) (t IndexIntroMessage) (t IndexIntroButtonText)
-        , viewFeatured sharedData.time (Data.PlaceCal.Events.eventsWithPartners sharedData.events sharedData.partners) filterByRegionId
+        , viewFeatured localModel.nowTime (Data.PlaceCal.Events.eventsWithPartners sharedData.events sharedData.partners) localModel.filterByRegion
         , viewLatestNews (List.head sharedData.articles) (t IndexNewsHeader) (t IndexNewsButtonText)
         ]
 
@@ -54,7 +61,7 @@ viewFeatured fromTime eventList regionId =
     section [ css [ sectionStyle, Theme.Global.darkBlueBackgroundStyle, eventsSectionStyle ] ]
         [ h2 [ css [ Theme.Global.smallFloatingTitleStyle ] ] [ text (t IndexFeaturedHeader) ]
         , Theme.RegionSelector.viewRegionSelector { filterBy = regionId }
-        , Theme.Page.Events.viewEventsList { filterByDate = Theme.Paginator.None, filterByRegion = regionId, nowTime = fromTime } eventList (Just 8)
+        , Theme.Page.Events.viewEventsList { filterByDate = Theme.Paginator.Future, filterByRegion = regionId, nowTime = fromTime } eventList (Just 8)
         , p [ css [ Theme.Global.buttonFloatingWrapperStyle, width (calc (pct 100) minus (rem 2)) ] ]
             [ a
                 [ href (Helpers.TransRoutes.toAbsoluteUrl Helpers.TransRoutes.Events)

--- a/src/Theme/Page/Index.elm
+++ b/src/Theme/Page/Index.elm
@@ -12,6 +12,7 @@ import Shared
 import Theme.Global
 import Theme.Page.Events
 import Theme.Page.News
+import Theme.Paginator
 import Theme.RegionSelector
 import Time
 
@@ -53,7 +54,7 @@ viewFeatured fromTime eventList regionId =
     section [ css [ sectionStyle, Theme.Global.darkBlueBackgroundStyle, eventsSectionStyle ] ]
         [ h2 [ css [ Theme.Global.smallFloatingTitleStyle ] ] [ text (t IndexFeaturedHeader) ]
         , Theme.RegionSelector.viewRegionSelector { filterBy = regionId }
-        , Theme.Page.Events.viewEventsList (Data.PlaceCal.Events.nextNEvents 8 (Data.PlaceCal.Events.eventsFromRegionId eventList regionId) fromTime)
+        , Theme.Page.Events.viewEventsList { filterByDate = Theme.Paginator.None, filterByRegion = regionId, nowTime = fromTime } eventList (Just 8)
         , p [ css [ Theme.Global.buttonFloatingWrapperStyle, width (calc (pct 100) minus (rem 2)) ] ]
             [ a
                 [ href (Helpers.TransRoutes.toAbsoluteUrl Helpers.TransRoutes.Events)

--- a/src/Theme/Page/Partner.elm
+++ b/src/Theme/Page/Partner.elm
@@ -9,9 +9,23 @@ import Html.Styled exposing (Html, a, address, div, h3, hr, p, section, span, te
 import Html.Styled.Attributes exposing (css, href, id, target)
 import Theme.Global exposing (hrStyle, introTextLargeStyle, linkStyle, normalFirstParagraphStyle, pink, smallInlineTitleStyle, white, withMediaMediumDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 import Theme.Page.Events
+import Theme.Paginator
 import Theme.TransMarkdown
+import Time
 
 
+viewInfo :
+    { a
+        | filterByDate : Theme.Paginator.Filter
+        , filterByRegion : Int
+        , nowTime : Time.Posix
+        , visibleEvents : List Data.PlaceCal.Events.Event
+    }
+    ->
+        { partner : Data.PlaceCal.Partners.Partner
+        , events : List Data.PlaceCal.Events.Event
+        }
+    -> Html Theme.Page.Events.Msg
 viewInfo localModel { partner, events } =
     section [ css [ margin2 (rem 0) (rem 0.35) ] ]
         [ text ""

--- a/src/Theme/Page/Partner.elm
+++ b/src/Theme/Page/Partner.elm
@@ -19,7 +19,6 @@ viewInfo :
         | filterByDate : Theme.Paginator.Filter
         , filterByRegion : Int
         , nowTime : Time.Posix
-        , visibleEvents : List Data.PlaceCal.Events.Event
     }
     ->
         { partner : Data.PlaceCal.Partners.Partner
@@ -42,7 +41,7 @@ viewInfo localModel { partner, events } =
                 ]
             ]
         , hr [ css [ hrStyle ] ] []
-        , viewPartnerEvents localModel { partner = partner, events = events }
+        , viewPartnerEvents events localModel partner
         , case partner.maybeGeo of
             Just geo ->
                 div [ css [ mapContainerStyle ] ]
@@ -58,7 +57,17 @@ viewInfo localModel { partner, events } =
         ]
 
 
-viewPartnerEvents localModel { partner, events } =
+viewPartnerEvents :
+    List Data.PlaceCal.Events.Event
+    ->
+        { a
+            | filterByDate : Theme.Paginator.Filter
+            , filterByRegion : Int
+            , nowTime : Time.Posix
+        }
+    -> Data.PlaceCal.Partners.Partner
+    -> Html Theme.Page.Events.Msg
+viewPartnerEvents events localModel partner =
     let
         eventAreaTitle =
             h3 [ css [ smallInlineTitleStyle, color white ] ] [ text (t (PartnerUpcomingEventsText partner.name)) ]
@@ -67,7 +76,8 @@ viewPartnerEvents localModel { partner, events } =
         (if List.length events > 0 then
             if List.length events > 20 then
                 [ eventAreaTitle
-                , Theme.Page.Events.viewEvents localModel
+                , Theme.Paginator.viewPagination localModel |> Html.Styled.map Theme.Page.Events.fromPaginatorMsg
+                , Theme.Page.Events.viewEventsList localModel events Nothing
                 ]
 
             else
@@ -81,7 +91,7 @@ viewPartnerEvents localModel { partner, events } =
                 [ if List.length futureEvents > 0 then
                     div []
                         [ eventAreaTitle
-                        , Theme.Page.Events.viewEventsList futureEvents
+                        , Theme.Page.Events.viewEventsList localModel futureEvents Nothing
                         ]
 
                   else
@@ -89,7 +99,7 @@ viewPartnerEvents localModel { partner, events } =
                 , if List.length pastEvents > 0 then
                     div []
                         [ h3 [ css [ smallInlineTitleStyle, color white ] ] [ text (t (PartnerPreviousEventsText partner.name)) ]
-                        , Theme.Page.Events.viewEventsList pastEvents
+                        , Theme.Page.Events.viewEventsList localModel pastEvents Nothing
                         ]
 
                   else

--- a/src/Theme/Paginator.elm
+++ b/src/Theme/Paginator.elm
@@ -1,4 +1,4 @@
-module Theme.Paginator exposing (Filter(..), Msg(..), ScrollDirection(..), fromMsg, scrollPagination, viewPagination)
+module Theme.Paginator exposing (Filter(..), Msg(..), ScrollDirection(..), scrollPagination, viewPagination)
 
 import Browser.Dom exposing (Error, Viewport, getViewportOf, setViewportOf)
 import Copy.Keys exposing (Key(..))

--- a/src/Theme/Paginator.elm
+++ b/src/Theme/Paginator.elm
@@ -1,4 +1,4 @@
-module Theme.Paginator exposing (Filter(..), Msg(..), ScrollDirection(..), scrollPagination, viewPagination)
+module Theme.Paginator exposing (Filter(..), Msg(..), ScrollDirection(..), filterEvents, scrollPagination, viewPagination)
 
 import Browser.Dom exposing (Error, Viewport, getViewportOf, setViewportOf)
 import Copy.Keys exposing (Key(..))
@@ -6,6 +6,7 @@ import Copy.Text exposing (t)
 import Css exposing (Style, active, auto, backgroundColor, batch, borderBox, borderColor, borderRadius, borderStyle, borderWidth, boxSizing, center, color, cursor, deg, display, displayFlex, fitContent, flexWrap, focus, fontSize, fontWeight, height, hover, important, int, justifyContent, listStyleType, margin, margin2, margin4, maxWidth, noWrap, none, overflowX, padding2, padding4, paddingLeft, paddingRight, pct, pointer, position, property, pseudoElement, px, relative, rem, rotate, scroll, solid, textAlign, transform, width, wrap)
 import Css.Global exposing (descendants, typeSelector)
 import Css.Transitions exposing (transition)
+import Data.PlaceCal.Events
 import Helpers.TransDate as TransDate
 import Html.Styled exposing (Html, button, div, img, li, text, ul)
 import Html.Styled.Attributes exposing (css, id, src)
@@ -108,6 +109,25 @@ viewPagination localModel =
                 ]
             ]
         ]
+
+
+filterEvents : Time.Posix -> Filter -> List Data.PlaceCal.Events.Event -> List Data.PlaceCal.Events.Event
+filterEvents now filter eventList =
+    case filter of
+        Day time ->
+            Data.PlaceCal.Events.eventsFromDate eventList time
+
+        Past ->
+            List.reverse (Data.PlaceCal.Events.onOrBeforeDate eventList now)
+
+        Future ->
+            Data.PlaceCal.Events.afterDate eventList now
+
+        None ->
+            eventList
+
+        Unknown ->
+            eventList
 
 
 todayTomorrowNext5DaysPosix : Time.Posix -> List ( String, Time.Posix )

--- a/src/Theme/Paginator.elm
+++ b/src/Theme/Paginator.elm
@@ -1,4 +1,4 @@
-module Theme.Paginator exposing (Filter(..), Msg(..), ScrollDirection(..), scrollPagination, viewPagination)
+module Theme.Paginator exposing (Filter(..), Msg(..), ScrollDirection(..), fromMsg, scrollPagination, viewPagination)
 
 import Browser.Dom exposing (Error, Viewport, getViewportOf, setViewportOf)
 import Copy.Keys exposing (Key(..))
@@ -41,7 +41,7 @@ type ScrollDirection
 
 viewPagination :
     { localModel
-        | filterBy : Filter
+        | filterByDate : Filter
         , nowTime : Time.Posix
     }
     -> Html Msg
@@ -56,7 +56,7 @@ viewPagination localModel =
                             li [ css [ paginationButtonListItemStyle ] ]
                                 [ button
                                     [ css
-                                        [ case localModel.filterBy of
+                                        [ case localModel.filterByDate of
                                             Day day ->
                                                 if TransDate.isSameDay buttonTime day then
                                                     paginationButtonListItemButtonActiveStyle
@@ -82,7 +82,7 @@ viewPagination localModel =
                 [ li [ css [ allEventsButtonListItemStyle ] ]
                     [ button
                         [ css
-                            (if localModel.filterBy == Past then
+                            (if localModel.filterByDate == Past then
                                 [ important (width (px 200)), paginationButtonListItemButtonActiveStyle ]
 
                              else
@@ -95,7 +95,7 @@ viewPagination localModel =
                 , li [ css [ allEventsButtonListItemStyle ] ]
                     [ button
                         [ css
-                            (if localModel.filterBy == Future then
+                            (if localModel.filterByDate == Future then
                                 [ important (width (px 200)), paginationButtonListItemButtonActiveStyle ]
 
                              else

--- a/src/Theme/RegionSelector.elm
+++ b/src/Theme/RegionSelector.elm
@@ -1,0 +1,207 @@
+module Theme.RegionSelector exposing (Msg(..), viewRegionSelector)
+
+import Copy.Keys exposing (Key(..))
+import Copy.Text exposing (t)
+import Css exposing (Style, active, auto, backgroundColor, batch, borderBox, borderColor, borderRadius, borderStyle, borderWidth, boxSizing, center, color, cursor, displayFlex, fitContent, flexWrap, focus, fontSize, fontWeight, hover, int, justifyContent, listStyleType, margin2, margin4, maxWidth, none, padding4, pointer, position, property, px, relative, rem, solid, textAlign, width, wrap)
+import Css.Global exposing (descendants, typeSelector)
+import Css.Transitions exposing (transition)
+import Data.PlaceCal.Partners
+import Html.Styled exposing (Html, button, div, li, text, ul)
+import Html.Styled.Attributes exposing (css)
+import Html.Styled.Events
+import Theme.Global exposing (backgroundColorTransition, borderTransition, colorTransition, darkBlue, darkPurple, white, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
+
+
+type Msg
+    = ClickedSelector Int
+
+
+viewRegionSelector :
+    { localModel
+        | filterBy : Int
+    }
+    -> Html Msg
+viewRegionSelector localModel =
+    div [ css [ regionSelectorWrapper ] ]
+        [ div [ css [ regionSelectorContainer ] ]
+            [ ul [ css [ regionSelectorButtonListStyle ] ]
+                (List.map
+                    (\tagInfo -> viewButton tagInfo (tagInfo.id == localModel.filterBy))
+                    ({ id = 0, name = t AllRegionSelectorLabel }
+                        :: Data.PlaceCal.Partners.partnershipTagList
+                    )
+                )
+            ]
+        ]
+
+
+viewButton : { id : Int, name : String } -> Bool -> Html Msg
+viewButton tagInfo isActive =
+    li [ css [ regionSelectorButtonListItemStyle ] ]
+        [ button
+            [ css
+                [ if isActive then
+                    regionSelectorButtonListItemButtonActiveStyle
+
+                  else
+                    regionSelectorButtonListItemButtonStyle
+                ]
+            , Html.Styled.Events.onClick (ClickedSelector tagInfo.id)
+            ]
+            [ text tagInfo.name ]
+        ]
+
+
+
+-- Styles
+
+
+numberOfButtons : Float
+numberOfButtons =
+    List.length Data.PlaceCal.Partners.partnershipTagList
+        + 1
+        |> toFloat
+
+
+buttonWidthMobile : Float
+buttonWidthMobile =
+    100
+
+
+buttonMarginMobile : Float
+buttonMarginMobile =
+    4
+
+
+buttonWidthTablet : Float
+buttonWidthTablet =
+    110
+
+
+buttonMarginTablet : Float
+buttonMarginTablet =
+    6
+
+
+buttonWidthFullWidth : Float
+buttonWidthFullWidth =
+    140
+
+
+buttonMarginFullWidth : Float
+buttonMarginFullWidth =
+    8
+
+
+regionSelectorWrapper : Style
+regionSelectorWrapper =
+    batch
+        [ margin2 (rem 0) (rem -0.5)
+        , withMediaSmallDesktopUp [ margin4 (rem 2) (rem -1) (rem 3) (rem -1) ]
+        , withMediaTabletLandscapeUp [ margin2 (rem 2) (rem -1) ]
+        ]
+
+
+regionSelectorContainer : Style
+regionSelectorContainer =
+    batch
+        [ displayFlex
+        , maxWidth fitContent
+        , margin4 (rem 0) auto (rem 0.5) auto
+        , withMediaSmallDesktopUp [ margin2 (rem 0) auto ]
+        , withMediaTabletLandscapeUp [ margin2 (rem 0) auto ]
+        ]
+
+
+regionSelectorButtonStyle : Style
+regionSelectorButtonStyle =
+    batch
+        [ borderStyle solid
+        , borderColor white
+        , borderWidth (px 2)
+        , color white
+        , borderRadius (rem 0.3)
+        , textAlign center
+        , cursor pointer
+        , hover
+            [ backgroundColor darkPurple
+            , color white
+            , borderColor white
+            , descendants [ typeSelector "img" [ property "filter" "invert(1)" ] ]
+            ]
+        , focus
+            [ backgroundColor white
+            , color darkBlue
+            , borderColor white
+            , descendants [ typeSelector "img" [ property "filter" "invert(0)" ] ]
+            ]
+        , active
+            [ backgroundColor white
+            , color darkBlue
+            , borderColor white
+            , descendants [ typeSelector "img" [ property "filter" "invert(0)" ] ]
+            ]
+        , transition [ colorTransition, borderTransition, backgroundColorTransition ]
+        ]
+
+
+buttonListStyle : Style
+buttonListStyle =
+    batch
+        [ displayFlex
+        , justifyContent center
+        , boxSizing borderBox
+        , position relative
+        , width (px (buttonWidthMobile * numberOfButtons + buttonMarginMobile * (numberOfButtons * 2)))
+        , withMediaTabletLandscapeUp
+            [ width (px (buttonWidthFullWidth * numberOfButtons + buttonMarginFullWidth * (numberOfButtons * 5))) ]
+        , withMediaTabletPortraitUp
+            [ width (px (buttonWidthTablet * numberOfButtons + buttonMarginTablet * (numberOfButtons * 2))) ]
+        ]
+
+
+regionSelectorButtonListStyle : Style
+regionSelectorButtonListStyle =
+    batch
+        [ buttonListStyle
+        , flexWrap wrap
+        ]
+
+
+regionSelectorButtonListItemStyle : Style
+regionSelectorButtonListItemStyle =
+    batch
+        [ margin2 (rem 0.25) (px buttonMarginMobile)
+        , listStyleType none
+        , withMediaTabletLandscapeUp [ margin2 (rem 0.25) (rem 0.5) ]
+        , withMediaTabletPortraitUp [ margin2 (rem 0.25) (rem 0.375) ]
+        ]
+
+
+regionSelectorButtonListItemButtonStyle : Style
+regionSelectorButtonListItemButtonStyle =
+    batch
+        [ regionSelectorButtonStyle
+        , fontSize (rem 0.875)
+        , fontWeight (int 600)
+        , padding4 (rem 0.2) (rem 0.2) (rem 0.3) (rem 0.2)
+        , width (px buttonWidthMobile)
+        , backgroundColor darkBlue
+        , withMediaTabletLandscapeUp [ width (px buttonWidthFullWidth), fontSize (rem 1.2) ]
+        , withMediaTabletPortraitUp [ width (px buttonWidthTablet), fontSize (rem 1) ]
+        ]
+
+
+regionSelectorButtonListItemButtonActiveStyle : Style
+regionSelectorButtonListItemButtonActiveStyle =
+    batch
+        [ regionSelectorButtonStyle
+        , fontSize (rem 0.875)
+        , fontWeight (int 600)
+        , padding4 (rem 0.2) (rem 0.2) (rem 0.3) (rem 0.2)
+        , width (px buttonWidthMobile)
+        , backgroundColor white
+        , color darkBlue
+        , withMediaTabletLandscapeUp [ width (px buttonWidthFullWidth), fontSize (rem 1.2) ]
+        , withMediaTabletPortraitUp [ width (px buttonWidthTablet), fontSize (rem 1) ]
+        ]


### PR DESCRIPTION
Fixes #408

## Description

- Adds regional selector to index page
- Moves event lists out of model & instead calculate from filters
- Correct featured events on index to show draw from all future, not just today

TODO: Would like to add tests for event listings

<sub><a href="https://huly.app/guest/geeksforsocialchange?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzJlNTllNGU3Y2M1YTc4NTQyOTk0OWYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Incta2ltLWdlZWtzZm9yc29jaS02NzFlNzVmOS03ZTVlMTU1YzMwLTIxZjkwZCJ9.6sYBEmyV2h63ye48FPotHgVNikrmCyXvBN_xRYIol54">Huly&reg;: <b>TD-453</b></a></sub>