### PR TITLE
Move plausible tracker embed into vite config

### DIFF
--- a/app/Shared.elm
+++ b/app/Shared.elm
@@ -135,7 +135,6 @@ view sharedData page model toMsg pageView =
         [ Html.Styled.toUnstyled
             (Theme.Global.containerPage pageView.title
                 [ View.fontPreload
-                , View.plausibleTracker
                 , Theme.Global.globalStyles
                 , viewPageHeader page
                     { showMobileMenu = model.showMobileMenu }

--- a/app/View.elm
+++ b/app/View.elm
@@ -1,4 +1,4 @@
-module View exposing (View, fontPreload, map, plausibleTracker)
+module View exposing (View, fontPreload, map)
 
 import Html.Styled exposing (Html, node)
 import Html.Styled.Attributes exposing (attribute, href, rel, src)
@@ -22,15 +22,5 @@ fontPreload =
     node "link"
         [ rel "stylesheet preload"
         , href "https://use.typekit.net/qwi3qrw.css"
-        ]
-        []
-
-
-plausibleTracker : Html msg
-plausibleTracker =
-    node "SCRIPT"
-        [ attribute "defer" "defer"
-        , attribute "data-domain" "transdimension.uk"
-        , src "https://plausible.io/js/plausible.js"
         ]
         []

--- a/elm-pages.config.mjs
+++ b/elm-pages.config.mjs
@@ -8,6 +8,7 @@ export default {
     return `
 <link rel="stylesheet" href="/style.css" />
 <meta name="generator" content="elm-pages v${context.cliVersion}" />
+<script defer="defer" data-domain="transdimension.uk" src="https://plausible.io/js/script.outbound-links.js"></script>
 `;
   },
   preloadTagForFile(file) {


### PR DESCRIPTION
Fixes #458 

## Description

- elm-pages v3 was sanitising arbitrary injection of scripts https://github.com/dillonkearns/elm-pages/discussions/339
- move plausible script into vite config
