### PR TITLE
fix: add summary to partner show pages

### DIFF
--- a/src/Copy/Keys.elm
+++ b/src/Copy/Keys.elm
@@ -90,7 +90,7 @@ type Key
     | PartnerContactsEmptyText
     | PartnerAddressHeading
     | PartnerAddressEmptyText
-    | PartnerDescriptionText String String
+    | PartnerDescriptionEmptyText String
     | PartnerUpcomingEventsText String
     | PartnerPreviousEventsText String
     | PartnerEventsEmptyText String

--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -261,12 +261,8 @@ t key =
         PartnerAddressEmptyText ->
             "No address provided"
 
-        PartnerDescriptionText partnerDescription partnerName ->
-            if String.isEmpty partnerDescription then
-                "Please ask " ++ partnerName ++ " for more information"
-
-            else
-                partnerDescription
+        PartnerDescriptionEmptyText partnerName ->
+            "Please ask " ++ partnerName ++ " for more information"
 
         PartnerUpcomingEventsText partnerName ->
             "Upcoming events by " ++ partnerName

--- a/src/Theme/Page/Partner.elm
+++ b/src/Theme/Page/Partner.elm
@@ -18,6 +18,7 @@ viewInfo localModel { partner, events } =
         , div [ css [ descriptionStyle ] ]
             (Theme.TransMarkdown.markdownToHtml
                 (t (PartnerDescriptionText partner.summary partner.name)
+                    ++ "\n\n"
                     ++ t (PartnerDescriptionText partner.description partner.name)
                 )
             )

--- a/src/Theme/Page/Partner.elm
+++ b/src/Theme/Page/Partner.elm
@@ -2,7 +2,7 @@ module Theme.Page.Partner exposing (viewInfo)
 
 import Copy.Keys exposing (Key(..))
 import Copy.Text exposing (t)
-import Css exposing (Style, auto, batch, calc, center, color, displayFlex, fontStyle, important, margin2, margin4, marginBlockEnd, marginBlockStart, marginTop, maxWidth, minus, normal, pct, px, rem, textAlign, width)
+import Css exposing (Style, auto, batch, calc, center, color, displayFlex, fontStyle, important, margin2, margin4, marginBlockEnd, marginBlockStart, marginTop, maxWidth, minus, normal, pct, px, rem, textAlign, text_, width)
 import Data.PlaceCal.Events
 import Data.PlaceCal.Partners
 import Html.Styled exposing (Html, a, address, div, h3, hr, p, section, span, text)
@@ -15,7 +15,12 @@ import Theme.TransMarkdown
 viewInfo localModel { partner, events } =
     section [ css [ margin2 (rem 0) (rem 0.35) ] ]
         [ text ""
-        , div [ css [ descriptionStyle ] ] (Theme.TransMarkdown.markdownToHtml (t (PartnerDescriptionText partner.description partner.name)))
+        , div [ css [ descriptionStyle ] ]
+            (Theme.TransMarkdown.markdownToHtml
+                (t (PartnerDescriptionText partner.summary partner.name)
+                    ++ t (PartnerDescriptionText partner.description partner.name)
+                )
+            )
         , hr [ css [ hrStyle ] ] []
         , section [ css [ contactWrapperStyle ] ]
             [ div [ css [ contactSectionStyle ] ]

--- a/src/Theme/Page/Partner.elm
+++ b/src/Theme/Page/Partner.elm
@@ -2,7 +2,7 @@ module Theme.Page.Partner exposing (viewInfo)
 
 import Copy.Keys exposing (Key(..))
 import Copy.Text exposing (t)
-import Css exposing (Style, auto, batch, calc, center, color, displayFlex, fontStyle, important, margin2, margin4, marginBlockEnd, marginBlockStart, marginTop, maxWidth, minus, normal, pct, px, rem, textAlign, text_, width)
+import Css exposing (Style, auto, batch, calc, center, color, displayFlex, fontStyle, important, margin2, margin4, marginBlockEnd, marginBlockStart, marginTop, maxWidth, minus, normal, pct, px, rem, textAlign, width)
 import Data.PlaceCal.Events
 import Data.PlaceCal.Partners
 import Html.Styled exposing (Html, a, address, div, h3, hr, p, section, span, text)
@@ -29,12 +29,7 @@ viewInfo localModel { partner, events } =
     section [ css [ margin2 (rem 0) (rem 0.35) ] ]
         [ text ""
         , div [ css [ descriptionStyle ] ]
-            (Theme.TransMarkdown.markdownToHtml
-                (t (PartnerDescriptionText partner.summary partner.name)
-                    ++ "\n\n"
-                    ++ t (PartnerDescriptionText partner.description partner.name)
-                )
-            )
+            (viewPartnerDescription partner.name partner.description partner.summary)
         , hr [ css [ hrStyle ] ] []
         , section [ css [ contactWrapperStyle ] ]
             [ div [ css [ contactSectionStyle ] ]
@@ -179,7 +174,15 @@ viewAddress maybeAddress =
         Nothing ->
             p [ css [ contactItemStyle ] ] [ text (t PartnerAddressEmptyText) ]
 
-
+viewPartnerDescription : String -> String -> String -> List (Html msg)
+viewPartnerDescription partnerName partnerDescription partnerSummary =
+    case (partnerDescription, partnerSummary) of
+        ("", "") -> [ div [ ] (Theme.TransMarkdown.markdownToHtml (t (PartnerDescriptionEmptyText partnerName))) ]
+        ( "", s) -> [ div [ ] (Theme.TransMarkdown.markdownToHtml s) ]
+        (d, "")  -> [ div [ ] (Theme.TransMarkdown.markdownToHtml d) ]
+        (d, s)   -> [ div [ ] (Theme.TransMarkdown.markdownToHtml s)
+                    , div [ ] (Theme.TransMarkdown.markdownToHtml d)
+                    ]
 
 ---------
 -- Styles


### PR DESCRIPTION
Fixes #433

## Description

Shows summary and description on show pages.

Note that this bug existing has resulted in people improvising in the backend repeating info - example below. We may need to do some post-fix cleanup.

<img width="1231" src="https://github.com/user-attachments/assets/2a774f00-f170-4cb3-a519-43264a4ddab1" alt="Screenshot 2024-11-20 at 16 24 23">

Screenshot showing change vs original bug ticket:

<img width="1012" src="https://github.com/user-attachments/assets/3056ab88-8cef-42a5-b64b-9779a563fb16" alt="Screenshot 2024-11-20 at 16 29 39">

<sub><a href="https://huly.app/guest/geeksforsocialchange?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzNlMGQ2M2U3Y2M1YTc4NTQyZTVlN2MiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Incta2ltLWdlZWtzZm9yc29jaS02NzFlNzVmOS03ZTVlMTU1YzMwLTIxZjkwZCJ9.cnX74TV1oKygD20MDP1CW0K_oxUE0PLOAI1e1uhNxdo">Huly&reg;: <b>TD-458</b></a></sub>