### PR TITLE
feat: Add filter by region to Partners index

### DIFF
--- a/app/Route/Partners.elm
+++ b/app/Route/Partners.elm
@@ -9,34 +9,73 @@ module Route.Partners exposing (Model, Msg, RouteParams, route, Data, ActionData
 import BackendTask
 import Copy.Keys exposing (Key(..))
 import Copy.Text exposing (t)
+import Effect
 import FatalError
 import Head
+import Html.Styled
 import PagesMsg
 import RouteBuilder
 import Shared
 import Theme.Page.Partners
 import Theme.PageTemplate
+import Theme.RegionSelector exposing (Msg(..))
+import UrlPath
 import View
 
 
 type alias Model =
-    {}
+    { filterByRegion : Int }
 
 
 type alias Msg =
-    ()
+    Theme.RegionSelector.Msg
 
 
 type alias RouteParams =
     {}
 
 
-route : RouteBuilder.StatelessRoute RouteParams Data ActionData
+init :
+    RouteBuilder.App Data ActionData RouteParams
+    -> Shared.Model
+    -> ( Model, Effect.Effect Msg )
+init _ _ =
+    ( { filterByRegion = 0 }
+    , Effect.none
+    )
+
+
+update :
+    RouteBuilder.App Data ActionData RouteParams
+    -> Shared.Model
+    -> Msg
+    -> Model
+    -> ( Model, Effect.Effect Msg )
+update app _ msg model =
+    case msg of
+        ClickedSelector tagId ->
+            ( { model
+                | filterByRegion = tagId
+              }
+            , Effect.none
+            )
+
+
+subscriptions : RouteParams -> UrlPath.UrlPath -> Shared.Model -> Model -> Sub Msg
+subscriptions _ _ _ _ =
+    Sub.none
+
+
+route : RouteBuilder.StatefulRoute RouteParams Data ActionData Model Msg
 route =
     RouteBuilder.single
         { data = data, head = head }
-        |> RouteBuilder.buildNoState
-            { view = view }
+        |> RouteBuilder.buildWithLocalState
+            { init = init
+            , view = view
+            , update = update
+            , subscriptions = subscriptions
+            }
 
 
 type alias Data =
@@ -64,8 +103,9 @@ head _ =
 view :
     RouteBuilder.App Data ActionData RouteParams
     -> Shared.Model
+    -> Model
     -> View.View (PagesMsg.PagesMsg Msg)
-view app _ =
+view app _ model =
     { title = t (PageMetaTitle (t PartnersTitle))
     , body =
         [ Theme.PageTemplate.view
@@ -73,7 +113,11 @@ view app _ =
             , title = t PartnersTitle
             , bigText = { text = t PartnersIntroSummary, node = "p" }
             , smallText = Just [ t PartnersIntroDescription ]
-            , innerContent = Just (Theme.Page.Partners.viewPartners app.sharedData.partners)
+            , innerContent =
+                Just
+                    (Theme.Page.Partners.viewPartners app.sharedData.partners model
+                        |> Html.Styled.map PagesMsg.fromMsg
+                    )
             , outerContent = Nothing
             }
         ]

--- a/src/Copy/Keys.elm
+++ b/src/Copy/Keys.elm
@@ -80,6 +80,7 @@ type Key
     | PartnersMetaDescription
     | PartnersIntroSummary
     | PartnersIntroDescription
+    | PartnersListHeading
     | PartnersListEmpty
     | PartnersMapAltText
       --- Partner Page

--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -233,6 +233,9 @@ t key =
         PartnersIntroDescription ->
             "All of our partners are explicitly trans-friendly organisations. Some are led by trans people, and some led by friends and allies. They put on events, provide services and offer support for members of our community."
 
+        PartnersListHeading ->
+            "All partners"
+
         PartnersListEmpty ->
             "There are currently no Trans Dimension partners"
 

--- a/src/Data/PlaceCal/Partners.elm
+++ b/src/Data/PlaceCal/Partners.elm
@@ -1,4 +1,4 @@
-module Data.PlaceCal.Partners exposing (Address, Contact, Partner, ServiceArea, partnerFromSlug, partnerNamesFromIds, partnersData, partnershipTagIdList, partnershipTagList)
+module Data.PlaceCal.Partners exposing (Address, Contact, Partner, ServiceArea, partnerFromSlug, partnerNamesFromIds, partnersData, partnersFromRegionId, partnershipTagIdList, partnershipTagList)
 
 import BackendTask
 import BackendTask.Custom
@@ -228,3 +228,13 @@ partnerNamesFromIds partnerList idList =
     -- If the partner isn't in our sites partners, it won't be in the list
     List.filter (\partner -> List.member partner.id idList) partnerList
         |> List.map (\partner -> partner.name)
+
+
+partnersFromRegionId : List Partner -> Int -> List Partner
+partnersFromRegionId partnerList regionId =
+    -- Region 0 is everywhere
+    if regionId == 0 then
+        List.sortBy .name partnerList
+
+    else
+        List.filter (\partner -> partner.partnershipTagId == regionId) partnerList

--- a/src/Theme/Page/Partners.elm
+++ b/src/Theme/Page/Partners.elm
@@ -10,18 +10,27 @@ import Helpers.TransRoutes as TransRoutes exposing (Route(..))
 import Html.Styled exposing (Html, a, div, h3, h4, li, p, section, span, styled, text, ul)
 import Html.Styled.Attributes exposing (css, href)
 import Theme.Global as Theme exposing (darkPurple, pink, purple, white, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
+import Theme.RegionSelector
 
 
-viewPartners : List Data.PlaceCal.Partners.Partner -> Html msg
-viewPartners partnerList =
+viewPartners :
+    List Data.PlaceCal.Partners.Partner
+    -> { localModel | filterByRegion : Int }
+    -> Html Theme.RegionSelector.Msg
+viewPartners partnerList model =
+    let
+        filteredPartnerList =
+            Data.PlaceCal.Partners.partnersFromRegionId partnerList model.filterByRegion
+    in
     section []
-        [ h3 [ css [ partnersListTitleStyle ] ] [ text "All partners" ]
-        , if List.length partnerList > 0 then
-            ul [ css [ listStyle ] ] (List.map (\partner -> viewPartner partner) partnerList)
+        [ h3 [ css [ partnersListTitleStyle ] ] [ text (t PartnersListHeading) ]
+        , Theme.RegionSelector.viewRegionSelector { filterBy = model.filterByRegion }
+        , if List.length filteredPartnerList > 0 then
+            ul [ css [ listStyle ] ] (List.map (\partner -> viewPartner partner) filteredPartnerList)
 
           else
             p [] [ text (t PartnersListEmpty) ]
-        , viewMap partnerList
+        , viewMap filteredPartnerList
         ]
 
 


### PR DESCRIPTION
Fixes #464
Fixes #408 

## Description

- Adds region filter to partners index page
- Alphabetises list of partners everywhere so regional partners are intermingled

<sub><a href="https://huly.app/guest/geeksforsocialchange?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzQzNGUzZWQyZWY0Y2JjYzQ2ODZmNjYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Incta2ltLWdlZWtzZm9yc29jaS02NzFlNzVmOS03ZTVlMTU1YzMwLTIxZjkwZCJ9.TrWZbA-ilZSbOoCNl02_u2L4J6yXCMQbAbUzRAwGbPo">Huly&reg;: <b>TD-466</b></a></sub>