### PR TITLE
fix mailto link in about

### DIFF
--- a/content/about/main.md
+++ b/content/about/main.md
@@ -9,4 +9,4 @@ At its core, The Trans Dimension is a digital partnership built on real-life tru
 
 The Trans Dimension is run by Geeks for Social Change in partnership with Gendered Intelligence with support from the Comic Relief Tech for Good programme.
 
-At this stage, the Trans Dimension is operating in London and Manchester. If you think you can help us roll it out in your area, please [get in touch](info@transdimension.uk).
+At this stage, the Trans Dimension is operating in London and Manchester. If you think you can help us roll it out in your area, please [get in touch](mailto:info@transdimension.uk).


### PR DESCRIPTION
Fixes #463

## Description

- Link to get in touch has mailto prefix

<sub><a href="https://huly.app/guest/geeksforsocialchange?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzU1YTUzYTFlMDYzMmRkMDhlMjU3YWUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Incta2ltLWdlZWtzZm9yc29jaS02NzFlNzVmOS03ZTVlMTU1YzMwLTIxZjkwZCJ9.Lg6MJsjx6WFXSFgNNsWG2BLOE9nPm2O317GCiw_cmMQ">Huly&reg;: <b>TD-472</b></a></sub>