### PR TITLE
Only filter partner events if there are more than 20

### DIFF
--- a/app/Route/Partners/Partner_.elm
+++ b/app/Route/Partners/Partner_.elm
@@ -34,7 +34,6 @@ import View
 type alias Model =
     { filterByDate : Theme.Paginator.Filter
     , filterByRegion : Int
-    , visibleEvents : List Data.PlaceCal.Events.Event
     , nowTime : Time.Posix
     , viewportWidth : Float
     , urlFragment : Maybe String
@@ -86,7 +85,6 @@ init app _ =
     in
     ( { filterByDate = Theme.Paginator.None
       , filterByRegion = 0
-      , visibleEvents = app.sharedData.events
       , nowTime = Time.millisToPosix 0
       , viewportWidth = 320
       , urlFragment = urlFragment
@@ -125,8 +123,6 @@ update app _ msg model =
                 Theme.Paginator.ClickedDay posix ->
                     ( { model
                         | filterByDate = Theme.Paginator.Day posix
-                        , visibleEvents =
-                            eventsFromPartnerId aPartner.id (Data.PlaceCal.Events.eventsFromDate app.sharedData.events posix)
                       }
                     , Effect.none
                     )
@@ -134,7 +130,6 @@ update app _ msg model =
                 Theme.Paginator.ClickedAllPastEvents ->
                     ( { model
                         | filterByDate = Theme.Paginator.Past
-                        , visibleEvents = eventsFromPartnerId aPartner.id (List.reverse (Data.PlaceCal.Events.onOrBeforeDate app.sharedData.events model.nowTime))
                       }
                     , Effect.none
                     )
@@ -142,7 +137,6 @@ update app _ msg model =
                 Theme.Paginator.ClickedAllFutureEvents ->
                     ( { model
                         | filterByDate = Theme.Paginator.Future
-                        , visibleEvents = eventsFromPartnerId aPartner.id (Data.PlaceCal.Events.afterDate app.sharedData.events model.nowTime)
                       }
                     , Effect.none
                     )
@@ -151,8 +145,6 @@ update app _ msg model =
                     ( { model
                         | filterByDate = Theme.Paginator.Day newTime
                         , nowTime = newTime
-                        , visibleEvents =
-                            eventsFromPartnerId aPartner.id (Data.PlaceCal.Events.eventsFromDate app.sharedData.events newTime)
                       }
                     , Effect.none
                     )

--- a/src/Theme/Page/Partner.elm
+++ b/src/Theme/Page/Partner.elm
@@ -71,42 +71,39 @@ viewPartnerEvents events localModel partner =
     let
         eventAreaTitle =
             h3 [ css [ smallInlineTitleStyle, color white ] ] [ text (t (PartnerUpcomingEventsText partner.name)) ]
+
+        futureEvents =
+            Data.PlaceCal.Events.afterDate events localModel.nowTime
+
+        pastEvents =
+            Data.PlaceCal.Events.onOrBeforeDate events localModel.nowTime
     in
     section [ id "events" ]
-        (if List.length events > 0 then
-            if List.length events > 20 then
+        (if List.length futureEvents > 0 then
+            -- If we have more than 20 future events paginate
+            if List.length futureEvents > 20 then
                 [ eventAreaTitle
                 , Theme.Paginator.viewPagination localModel |> Html.Styled.map Theme.Page.Events.fromPaginatorMsg
                 , Theme.Page.Events.viewEventsList localModel events Nothing
                 ]
 
             else
-                let
-                    futureEvents =
-                        Data.PlaceCal.Events.afterDate events localModel.nowTime
-
-                    pastEvents =
-                        Data.PlaceCal.Events.onOrBeforeDate events localModel.nowTime
-                in
-                [ if List.length futureEvents > 0 then
-                    div []
-                        [ eventAreaTitle
-                        , Theme.Page.Events.viewEventsList localModel futureEvents Nothing
-                        ]
-
-                  else
-                    div [] []
-                , if List.length pastEvents > 0 then
-                    div []
-                        [ h3 [ css [ smallInlineTitleStyle, color white ] ] [ text (t (PartnerPreviousEventsText partner.name)) ]
-                        , Theme.Page.Events.viewEventsList localModel pastEvents Nothing
-                        ]
-
-                  else
-                    div [] []
+                -- Otherwise show them all
+                [ div []
+                    [ Theme.Page.Events.viewEventsList localModel futureEvents Nothing
+                    ]
                 ]
 
+         else if List.length pastEvents > 0 then
+            -- If there are no future events but there were in the past, show them
+            [ div []
+                [ h3 [ css [ smallInlineTitleStyle, color white ] ] [ text (t (PartnerPreviousEventsText partner.name)) ]
+                , Theme.Page.Events.viewEventsList { localModel | filterByDate = Theme.Paginator.None } pastEvents Nothing
+                ]
+            ]
+
          else
+            -- This partner has never had events
             [ eventAreaTitle
             , p [ css [ introTextLargeStyle, color pink, important (maxWidth (px 636)) ] ] [ text (t (PartnerEventsEmptyText partner.name)) ]
             ]


### PR DESCRIPTION
Fixes #473 

## Description

- If there are more than 20 events in the future, show filters
- If there are no future events, show all past events
