### PR TITLE
fix: Show Instagram URL under Partner contact details

### DIFF
--- a/src/Data/PlaceCal/Partners.elm
+++ b/src/Data/PlaceCal/Partners.elm
@@ -17,6 +17,7 @@ type alias Partner =
     , summary : String
     , description : String
     , maybeUrl : Maybe String
+    , maybeInstagramUrl : Maybe String
     , maybeContactDetails : Maybe Contact
     , maybeAddress : Maybe Address
     , areasServed : List ServiceArea
@@ -61,6 +62,7 @@ emptyPartner =
     , summary = ""
     , description = ""
     , maybeUrl = Nothing
+    , maybeInstagramUrl = Nothing
     , maybeContactDetails = Nothing
     , maybeAddress = Nothing
     , areasServed = []
@@ -168,6 +170,7 @@ allPartnersQuery partnershipTag =
                   summary
                   contact { email, telephone }
                   url
+                  instagramUrl
                   address { streetAddress, postalCode, addressRegion, geo { latitude, longitude } }
                   areasServed { name abbreviatedName }
                   logo
@@ -193,6 +196,7 @@ decodePartner partnershipTagInt =
         |> Json.Decode.Pipeline.optional "summary" Json.Decode.string ""
         |> Json.Decode.Pipeline.optional "description" Json.Decode.string ""
         |> Json.Decode.Pipeline.optional "url" (Json.Decode.map Just Json.Decode.string) Nothing
+        |> Json.Decode.Pipeline.optional "instagramUrl" (Json.Decode.map Just Json.Decode.string) Nothing
         |> Json.Decode.Pipeline.optional "contact" (Json.Decode.map Just contactDecoder) Nothing
         |> Json.Decode.Pipeline.optional "address" (Json.Decode.map Just addressDecoder) Nothing
         |> Json.Decode.Pipeline.required "areasServed" (Json.Decode.list serviceAreaDecoder)

--- a/src/Theme/Page/Partner.elm
+++ b/src/Theme/Page/Partner.elm
@@ -33,7 +33,7 @@ viewInfo localModel { partner, events } =
         , section [ css [ contactWrapperStyle ] ]
             [ div [ css [ contactSectionStyle ] ]
                 [ h3 [ css [ contactHeadingStyle, Theme.Global.smallInlineTitleStyle ] ] [ text (t PartnerContactsHeading) ]
-                , viewContactDetails partner.maybeUrl partner.maybeContactDetails
+                , viewContactDetails partner.maybeUrl partner.maybeContactDetails partner.maybeInstagramUrl
                 ]
             , div [ css [ contactSectionStyle ] ]
                 [ h3 [ css [ contactHeadingStyle, Theme.Global.smallInlineTitleStyle ] ] [ text (t PartnerAddressHeading) ]
@@ -110,9 +110,9 @@ viewPartnerEvents events localModel partner =
         )
 
 
-viewContactDetails : Maybe String -> Maybe Data.PlaceCal.Partners.Contact -> Html msg
-viewContactDetails maybeUrl maybeContactDetails =
-    if maybeUrl == Nothing && maybeContactDetails == Nothing then
+viewContactDetails : Maybe String -> Maybe Data.PlaceCal.Partners.Contact -> Maybe String -> Html msg
+viewContactDetails maybeUrl maybeContactDetails maybeInstagramUrl =
+    if maybeUrl == Nothing && maybeContactDetails == Nothing && maybeInstagramUrl == Nothing then
         p [ css [ contactItemStyle ] ] [ text (t PartnerContactsEmptyText) ]
 
     else
@@ -146,6 +146,12 @@ viewContactDetails maybeUrl maybeContactDetails =
                 Just url ->
                     p [ css [ contactItemStyle ] ] [ a [ href url, target "_blank", css [ linkStyle ] ] [ text (Copy.Text.urlToDisplay url) ] ]
 
+                Nothing ->
+                    text ""
+            , case maybeInstagramUrl of
+                Just url ->
+                    p [ css [ contactItemStyle ] ] [ a [ href url, target "_blank", css [ linkStyle ] ] [ text (Copy.Text.urlToDisplay url) ] ]
+                
                 Nothing ->
                     text ""
             ]


### PR DESCRIPTION
Fixes #472

## Description

- Added Instagram URL to Partner type, query and decoder
- Added Instagram URL to Partner view

<sub><a href="https://huly.app/guest/geeksforsocialchange?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzVmMTUwZmYxNDRmNTg1YWU0ZDY0NjgiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Incta2ltLWdlZWtzZm9yc29jaS02NzFlNzVmOS03ZTVlMTU1YzMwLTIxZjkwZCJ9.Dd6LVVUdB_rdufy9enw5TQlEa_k3mTpM-zL_5Kx1w9U">Huly&reg;: <b>TD-478</b></a></sub>