### PR TITLE
fix: Show future events

### DIFF
--- a/src/Data/PlaceCal/Events.elm
+++ b/src/Data/PlaceCal/Events.elm
@@ -1,4 +1,4 @@
-module Data.PlaceCal.Events exposing (Event, EventPartner, afterDate, eventFromSlug, eventPartnerFromId, eventsData, eventsFromDate, eventsFromRegionId, eventsWithPartners, nextNEvents, onOrBeforeDate)
+module Data.PlaceCal.Events exposing (Event, EventPartner, afterDate, eventFromSlug, eventPartnerFromId, eventsData, eventsOnDate, eventsFromRegionId, eventsWithPartners, nextNEvents, onOrBeforeDate)
 
 import BackendTask
 import BackendTask.Custom
@@ -99,11 +99,11 @@ eventsFromRegionId eventList regionId =
         List.filter (\event -> event.partnershipTagId == regionId) eventList
 
 
-eventsFromDate : List Event -> Time.Posix -> List Event
-eventsFromDate eventList fromDate =
+eventsOnDate : List Event -> Time.Posix -> List Event
+eventsOnDate eventList onDate =
     List.filter
         (\event ->
-            TransDate.isSameDay event.startDatetime fromDate
+            TransDate.isSameDay event.startDatetime onDate
         )
         eventList
 

--- a/src/Theme/Page/Partner.elm
+++ b/src/Theme/Page/Partner.elm
@@ -91,7 +91,7 @@ viewPartnerEvents events localModel partner =
             else
                 -- Otherwise show them all
                 [ div []
-                    [ Theme.Page.Events.viewEventsList localModel futureEvents Nothing
+                    [ Theme.Page.Events.viewEventsList { localModel | filterByDate = Theme.Paginator.Future } events Nothing
                     ]
                 ]
 

--- a/src/Theme/Page/Partner.elm
+++ b/src/Theme/Page/Partner.elm
@@ -81,8 +81,8 @@ viewPartnerEvents events localModel partner =
     in
     section [ id "events" ]
         (if List.length futureEvents > 0 then
-            -- If we have more than 20 future events paginate
-            if List.length futureEvents > 20 then
+            -- If we have more than 40 future events paginate
+            if List.length futureEvents > 40 then
                 [ eventAreaTitle
                 , Theme.Paginator.viewPagination localModel |> Html.Styled.map Theme.Page.Events.fromPaginatorMsg
                 , Theme.Page.Events.viewEventsList localModel events Nothing

--- a/src/Theme/Paginator.elm
+++ b/src/Theme/Paginator.elm
@@ -115,7 +115,7 @@ filterEvents : Time.Posix -> Filter -> List Data.PlaceCal.Events.Event -> List D
 filterEvents now filter eventList =
     case filter of
         Day time ->
-            Data.PlaceCal.Events.eventsFromDate eventList time
+            Data.PlaceCal.Events.eventsOnDate eventList time
 
         Past ->
             List.reverse (Data.PlaceCal.Events.onOrBeforeDate eventList now)


### PR DESCRIPTION
Fixes #478

## Description

- Fixes incorrect filter applied to future event listings on Partner page
- Updates misleading function name

GFSC Partner page after fix:

![Screenshot 2024-12-17 at 15 48 43](https://github.com/user-attachments/assets/12c32d09-4120-48e5-b6f8-b962f9b5ed2b)

Mxer MCR Partner page after fix:

![Screenshot 2024-12-17 at 15 53 16](https://github.com/user-attachments/assets/6cfaa208-3f0f-42f2-8d4f-3e6141252938)

<sub><a href="https://huly.app/guest/geeksforsocialchange?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzYxOWU5NGYxNDRmNTg1YWU0ZGNhMjAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Incta2ltLWdlZWtzZm9yc29jaS02NzFlNzVmOS03ZTVlMTU1YzMwLTIxZjkwZCJ9.RLaqiEb8WcqFfJP5SMaQxEOpisH0G8V_fbZbqGIMl34">Huly&reg;: <b>TD-482</b></a></sub>