### PR TITLE
fix: Enable responsive UI on mobile devices

### DIFF
--- a/src/Theme/PageTemplate.elm
+++ b/src/Theme/PageTemplate.elm
@@ -71,7 +71,9 @@ stringToHeaderType maybeTypeString =
 
 pageMetaTags : { title : Key, description : Key, imageSrc : Maybe String } -> List Head.Tag
 pageMetaTags { title, description, imageSrc } =
-    Seo.summary
+    Head.metaName "viewport" (Head.raw "width=device-width, initial-scale=1") ::
+    (
+        Seo.summary
         { canonicalUrlOverride = Nothing
         , siteName = t SiteTitle
         , image =
@@ -93,6 +95,7 @@ pageMetaTags { title, description, imageSrc } =
         , title = t (PageMetaTitle (t title))
         }
         |> Seo.website
+    )
 
 
 view : PageUsingTemplate msg -> Html.Html msg


### PR DESCRIPTION
Fixes #476 

## Description

- The rendered HTML was missing a `viewport` meta tag, which is required for responsiveness on mobile devices (https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag)
- This tag has been added to `pageMetaTags` to apply to all pages

![Screenshot 2024-12-19 at 11 42 16](https://github.com/user-attachments/assets/063f8d55-99b6-4d36-8b40-4edc3b45673c)

<sub><a href="https://huly.app/guest/geeksforsocialchange?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzY0MDZmZWYxNDRmNTg1YWU0ZTNiNmYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Incta2ltLWdlZWtzZm9yc29jaS02NzFlNzVmOS03ZTVlMTU1YzMwLTIxZjkwZCJ9.NGy09T9E1RI49Tho-ly39Flzid17-gdryx-CfXCl8tA">Huly&reg;: <b>TD-485</b></a></sub>