### PR TITLE
Improve event metadata

### DIFF
--- a/src/Copy/Keys.elm
+++ b/src/Copy/Keys.elm
@@ -76,7 +76,7 @@ type Key
     | EventsFilterLabelAllFuture
       --- Event Page
     | EventTitle Prefix String
-    | EventMetaDescription String String
+    | EventMetaDescription String
     | BackToPartnerEventsLinkText (Maybe String)
     | BackToEventsLinkText
     | EventVisitPublisherUrlText (Maybe String)

--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -213,8 +213,8 @@ t key =
                 NoPrefix ->
                     eventName
 
-        EventMetaDescription eventName eventSummary ->
-            eventName ++ " - " ++ eventSummary
+        EventMetaDescription eventDescription ->
+            eventDescription
 
         BackToPartnerEventsLinkText partnerName ->
             "All events by " ++ Maybe.withDefault "this partner" partnerName


### PR DESCRIPTION
Closes #488.

Add date, time, host and description to event op tags.
Also fix a buggy behavior in the event page where the "All events by" button always display "All events by this partner" instead of "All events by {{ partner-name }}"

![2025-01-08 16_56_10](https://github.com/user-attachments/assets/27a17291-cecb-40f5-8674-0baa6cd10334)

<sub><a href="https://huly.app/guest/geeksforsocialchange?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzdlZGI3N2YxNDRmNTg1YWU1MzRlMjAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Incta2ltLWdlZWtzZm9yc29jaS02NzFlNzVmOS03ZTVlMTU1YzMwLTIxZjkwZCJ9.QqdFuwjCUxGERiv1ywt-vdz62EwKAK3c1vJF0KyAJeg">Huly&reg;: <b>TD-490</b></a></sub>