### PR TITLE
Change margin on the Partner pages without maps.

### DIFF
--- a/src/Theme/Page/Partner.elm
+++ b/src/Theme/Page/Partner.elm
@@ -54,7 +54,7 @@ viewInfo localModel { partner, events } =
                     ]
 
             Nothing ->
-                div [ css [ mapContainerStyle ] ] [ text "" ]
+                text ""
         ]
 
 
@@ -152,7 +152,7 @@ viewContactDetails maybeUrl maybeContactDetails maybeInstagramUrl =
             , case maybeInstagramUrl of
                 Just url ->
                     p [ css [ contactItemStyle ] ] [ a [ href url, target "_blank", css [ linkStyle ] ] [ text (Copy.Text.urlToDisplay url) ] ]
-                
+
                 Nothing ->
                     text ""
             ]
@@ -174,15 +174,25 @@ viewAddress maybeAddress =
         Nothing ->
             p [ css [ contactItemStyle ] ] [ text (t PartnerAddressEmptyText) ]
 
+
 viewPartnerDescription : String -> String -> String -> List (Html msg)
 viewPartnerDescription partnerName partnerDescription partnerSummary =
-    case (partnerDescription, partnerSummary) of
-        ("", "") -> [ div [ ] (Theme.TransMarkdown.markdownToHtml (t (PartnerDescriptionEmptyText partnerName))) ]
-        ( "", s) -> [ div [ ] (Theme.TransMarkdown.markdownToHtml s) ]
-        (d, "")  -> [ div [ ] (Theme.TransMarkdown.markdownToHtml d) ]
-        (d, s)   -> [ div [ ] (Theme.TransMarkdown.markdownToHtml s)
-                    , div [ ] (Theme.TransMarkdown.markdownToHtml d)
-                    ]
+    case ( partnerDescription, partnerSummary ) of
+        ( "", "" ) ->
+            [ div [] (Theme.TransMarkdown.markdownToHtml (t (PartnerDescriptionEmptyText partnerName))) ]
+
+        ( "", s ) ->
+            [ div [] (Theme.TransMarkdown.markdownToHtml s) ]
+
+        ( d, "" ) ->
+            [ div [] (Theme.TransMarkdown.markdownToHtml d) ]
+
+        ( d, s ) ->
+            [ div [] (Theme.TransMarkdown.markdownToHtml s)
+            , div [] (Theme.TransMarkdown.markdownToHtml d)
+            ]
+
+
 
 ---------
 -- Styles


### PR DESCRIPTION
Fixes #358 

## Description
Margin on the pages without maps was too small leading to 'cramped look'. Changed layout so more of a gap for cleaner look.

Before:

<img width="1163" alt="Screenshot 2025-01-13 at 17 33 24" src="https://github.com/user-attachments/assets/a30784fb-b6ca-43e4-934a-8c22f9b1aab3" />

After: 

<img width="1165" alt="Screenshot 2025-01-13 at 17 33 19" src="https://github.com/user-attachments/assets/5451d10d-61bd-4db8-9edb-01615ce42762" />

