### PR TITLE
Improve building time

### DIFF
--- a/app/Route/Events.elm
+++ b/app/Route/Events.elm
@@ -11,6 +11,7 @@ import Browser.Dom
 import Copy.Keys exposing (Key(..))
 import Copy.Text exposing (t)
 import Data.PlaceCal.Events
+import Data.PlaceCal.Partners
 import Effect
 import FatalError
 import Head
@@ -159,7 +160,9 @@ route =
 
 
 type alias Data =
-    ()
+    { events : List Data.PlaceCal.Events.Event
+    , partners : List Data.PlaceCal.Partners.Partner
+    }
 
 
 type alias ActionData =
@@ -168,7 +171,10 @@ type alias ActionData =
 
 data : BackendTask.BackendTask FatalError.FatalError Data
 data =
-    BackendTask.succeed ()
+    BackendTask.map2 Data
+        (BackendTask.map (\eventsData -> eventsData.allEvents) Data.PlaceCal.Events.eventsData)
+        (BackendTask.succeed [])
+        |> BackendTask.allowFatal
 
 
 head : RouteBuilder.App Data ActionData RouteParams -> List Head.Tag
@@ -193,7 +199,7 @@ view app _ model =
             , title = t EventsTitle
             , bigText = { text = t EventsSummary, node = "h3" }
             , smallText = Nothing
-            , innerContent = Just (Theme.Page.Events.viewEvents (Data.PlaceCal.Events.eventsWithPartners app.sharedData.events app.sharedData.partners) model)
+            , innerContent = Just (Theme.Page.Events.viewEvents (Data.PlaceCal.Events.eventsWithPartners app.data.events app.sharedData.partners) model)
             , outerContent = Nothing
             }
             |> Html.Styled.map PagesMsg.fromMsg

--- a/app/Route/Events/Event_.elm
+++ b/app/Route/Events/Event_.elm
@@ -43,7 +43,10 @@ route =
 
 
 type alias Data =
-    ()
+    -- { event : Data.PlaceCal.Events.Event
+    -- , partner : Data.PlaceCal.Partners.Partner
+    -- }
+    Data.PlaceCal.Events.Event
 
 
 type alias ActionData =
@@ -51,8 +54,10 @@ type alias ActionData =
 
 
 data : RouteParams -> BackendTask.BackendTask FatalError.FatalError Data
-data _ =
-    BackendTask.succeed ()
+data { event } =
+    Data.PlaceCal.Events.singleEventData
+        event
+        |> BackendTask.allowFatal
 
 
 pages : BackendTask.BackendTask FatalError.FatalError (List RouteParams)
@@ -70,7 +75,7 @@ head : RouteBuilder.App Data ActionData RouteParams -> List Head.Tag
 head app =
     let
         event =
-            Data.PlaceCal.Events.eventFromSlug app.routeParams.event app.sharedData.events
+            app.data
                 |> eventWithPartner app.sharedData.partners
     in
     Theme.PageTemplate.pageMetaTags
@@ -103,7 +108,7 @@ view app _ =
     let
         event : Data.PlaceCal.Events.Event
         event =
-            Data.PlaceCal.Events.eventFromSlug app.routeParams.event app.sharedData.events
+            app.data
                 |> eventWithPartner app.sharedData.partners
     in
     { title = t (PageMetaTitle event.name)

--- a/app/Route/Partners/Partner_.elm
+++ b/app/Route/Partners/Partner_.elm
@@ -29,6 +29,7 @@ import Theme.Paginator exposing (Msg(..))
 import Time
 import UrlPath
 import View
+import Data.PlaceCal.Events
 
 
 type alias Model =
@@ -183,7 +184,9 @@ subscriptions _ _ _ _ =
 
 
 type alias Data =
-    ()
+    {
+        events : List Data.PlaceCal.Events.Event
+    }
 
 
 type alias ActionData =
@@ -192,7 +195,9 @@ type alias ActionData =
 
 data : RouteParams -> BackendTask.BackendTask FatalError.FatalError Data
 data _ =
-    BackendTask.succeed ()
+    BackendTask.map Data
+        (BackendTask.map (\eventsData -> eventsData.allEvents) Data.PlaceCal.Events.eventsData)
+    |> BackendTask.allowFatal
 
 
 head : RouteBuilder.App Data ActionData RouteParams -> List Head.Tag
@@ -229,7 +234,7 @@ view app _ model =
                 Just
                     (Theme.Page.Partner.viewInfo model
                         { partner = aPartner
-                        , events = eventsFromPartnerId aPartner.id app.sharedData.events
+                        , events = eventsFromPartnerId aPartner.id app.data.events
                         }
                     )
             , outerContent = Just (Theme.Global.viewBackButton (Helpers.TransRoutes.toAbsoluteUrl Partners) (t BackToPartnersLinkText))

--- a/app/Shared.elm
+++ b/app/Shared.elm
@@ -44,7 +44,6 @@ template =
 type alias Data =
     { articles : List Data.PlaceCal.Articles.Article
     , partners : List Data.PlaceCal.Partners.Partner
-    , events : List Data.PlaceCal.Events.Event
     , time : Time.Posix
     }
 
@@ -123,10 +122,10 @@ update msg model =
         -- Shared
         SharedMsg _ ->
             ( model, Effect.none )
-        
+
         -- Update region filter
         SetRegion tagId ->
-            ( { model | filterParam = Just (tagId) }, Effect.none )
+            ( { model | filterParam = Just tagId }, Effect.none )
 
 
 subscriptions : UrlPath -> Model -> Sub Msg
@@ -136,10 +135,9 @@ subscriptions _ _ =
 
 data : BackendTask FatalError Data
 data =
-    BackendTask.map4 Data
+    BackendTask.map3 Data
         (BackendTask.map (\articlesData -> articlesData.allArticles) Data.PlaceCal.Articles.articlesData)
         (BackendTask.map (\partnersData -> partnersData.allPartners) Data.PlaceCal.Partners.partnersData)
-        (BackendTask.map (\eventsData -> eventsData.allEvents) Data.PlaceCal.Events.eventsData)
         -- Consider using Pages.builtAt or Server.Request.requestTime
         BackendTask.Time.now
         |> BackendTask.allowFatal

--- a/custom-backend-task.js
+++ b/custom-backend-task.js
@@ -37,6 +37,36 @@ async function fetchAndCachePlaceCalData(config, context) {
   return placeCalData;
 }
 
+async function fetchSinglePlaceCalData(config, context) {
+  try {
+    const collectionJson = await query(config.url, config.query.query, config.query.variables)
+    return collectionJson;
+  } catch (_error) {
+    console.error(_error)
+  }
+}
+
+
+function query(endPoint, query, variables) {
+  return new Promise((resolve, reject) => {
+    fetch(endPoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+      },
+      body: JSON.stringify({
+        variables,
+        query
+      })
+    })
+      .then(r => r.json())
+      .then(data => resolve(data))
+      .catch(err => reject(err));
+  });
+}
+
 export {
-  fetchAndCachePlaceCalData
+  fetchAndCachePlaceCalData,
+  fetchSinglePlaceCalData
 };

--- a/src/Data/PlaceCal/Api.elm
+++ b/src/Data/PlaceCal/Api.elm
@@ -1,4 +1,4 @@
-module Data.PlaceCal.Api exposing (fetchAndCachePlaceCalData)
+module Data.PlaceCal.Api exposing (fetchAndCachePlaceCalData, fetchSinglePlaceCalData)
 
 import BackendTask
 import BackendTask.Custom
@@ -20,3 +20,19 @@ fetchAndCachePlaceCalData collection query =
             , ( "query", query )
             ]
         )
+    >> BackendTask.quiet
+
+
+fetchSinglePlaceCalData :
+    String
+    -> Json.Encode.Value
+    -> (Json.Decode.Decoder a -> BackendTask.BackendTask { fatal : FatalError.FatalError, recoverable : BackendTask.Custom.Error } a)
+fetchSinglePlaceCalData entityId query =
+    BackendTask.Custom.run "fetchSinglePlaceCalData"
+        (Json.Encode.object
+            [ ( "entityId", Json.Encode.string entityId )
+            , ( "url", Json.Encode.string Constants.placecalApi )
+            , ( "query", query )
+            ]
+        )
+    >> BackendTask.quiet

--- a/src/Data/PlaceCal/Events.elm
+++ b/src/Data/PlaceCal/Events.elm
@@ -1,4 +1,4 @@
-module Data.PlaceCal.Events exposing (Event, EventPartner, afterDate, eventFromSlug, eventPartnerFromId, eventsData, eventsFromRegionId, eventsOnDate, eventsWithPartners, nextNEvents, onOrBeforeDate)
+module Data.PlaceCal.Events exposing (Event, EventPartner, afterDate, eventFromSlug, eventPartnerFromId, eventsData, eventsFromRegionId, eventsOnDate, eventsWithPartners, nextNEvents, onOrBeforeDate, singleEventData)
 
 import BackendTask
 import BackendTask.Custom
@@ -177,6 +177,14 @@ eventsData =
         |> BackendTask.map (\eventList -> { allEvents = eventList })
 
 
+singleEventData : String -> BackendTask.BackendTask { fatal : FatalError.FatalError, recoverable : BackendTask.Custom.Error } Event
+singleEventData eventId =
+    Data.PlaceCal.Api.fetchSinglePlaceCalData
+        eventId
+        (singleEventQuery eventId)
+        (singleEventDecoder 0)
+
+
 sortEventsByDate : List Event -> List Event
 sortEventsByDate events =
     List.sortBy
@@ -210,10 +218,50 @@ allEventsQuery partnershipTag =
         ]
 
 
+singleEventQuery : String -> Json.Encode.Value
+singleEventQuery eventId =
+    Json.Encode.object
+        [ ( "query"
+          , Json.Encode.string
+                """
+                query Event($id: ID!) {
+                  event(id: $id) {
+                    id
+                    name
+                    summary
+                    description
+                    startDate
+                    endDate
+                    address {
+                      streetAddress
+                      postalCode
+                      addressLocality
+                      addressRegion
+                    }
+                    organizer {
+                      id
+                      name
+                    }
+                  }
+                }
+                """
+          )
+        , ( "variables"
+          , Json.Encode.object
+                [ ( "id", Json.Encode.string eventId ) ]
+          )
+        ]
+
+
 eventsDecoder : Int -> Json.Decode.Decoder AllEventsResponse
 eventsDecoder partnershipTagInt =
     Json.Decode.succeed AllEventsResponse
         |> Json.Decode.Pipeline.requiredAt [ "data", "eventsByFilter" ] (Json.Decode.list (decodeEvent partnershipTagInt))
+
+
+singleEventDecoder : Int -> Json.Decode.Decoder Event
+singleEventDecoder partnershipTagInt =
+    Json.Decode.at [ "data", "event" ] (decodeEvent partnershipTagInt)
 
 
 decodeEvent : Int -> Json.Decode.Decoder Event

--- a/src/Data/PlaceCal/Partners.elm
+++ b/src/Data/PlaceCal/Partners.elm
@@ -1,4 +1,4 @@
-module Data.PlaceCal.Partners exposing (Address, Contact, Partner, ServiceArea, filterFromQueryString, partnerFromSlug, partnerNamesFromIds, partnersData, partnersFromRegionId, partnershipTagIdList, partnershipTagList)
+module Data.PlaceCal.Partners exposing (Address, Contact, Partner, ServiceArea, filterFromQueryString, partnerFromSlug, partnerNamesFromIds, partnersData, partnersFromRegionId, partnershipTagIdList, partnershipTagList, singlePartnerData)
 
 import BackendTask
 import BackendTask.Custom
@@ -155,6 +155,14 @@ partnersData =
         |> BackendTask.map (\partnerList -> { allPartners = partnerList })
 
 
+singlePartnerData : String -> BackendTask.BackendTask { fatal : FatalError.FatalError, recoverable : BackendTask.Custom.Error } Partner
+singlePartnerData partnerId =
+    Data.PlaceCal.Api.fetchSinglePlaceCalData
+        partnerId
+        (singlePartnerQuery partnerId)
+        (singlePartnerDecoder 0)
+
+
 allPartnersQuery : String -> Json.Encode.Value
 allPartnersQuery partnershipTag =
     Json.Encode.object
@@ -181,10 +189,44 @@ allPartnersQuery partnershipTag =
         ]
 
 
+singlePartnerQuery : String -> Json.Encode.Value
+singlePartnerQuery partnerId =
+    Json.Encode.object
+        [ ( "query"
+          , Json.Encode.string
+                """
+                query Partner($id: ID!) {
+                  partner(id: $id) {
+                    id
+                    name
+                    description
+                    summary
+                    contact { email, telephone }
+                    url
+                    instagramUrl
+                    address { streetAddress, postalCode, addressRegion, geo { latitude, longitude } }
+                    areasServed { name abbreviatedName }
+                    logo
+                  }
+                }
+                """
+          )
+        , ( "variables"
+          , Json.Encode.object
+                [ ( "id", Json.Encode.string partnerId ) ]
+          )
+        ]
+
+
 partnersDecoder : Int -> Json.Decode.Decoder AllPartnersResponse
 partnersDecoder partnershipTagInt =
     Json.Decode.succeed AllPartnersResponse
         |> Json.Decode.Pipeline.requiredAt [ "data", "partnersByTag" ] (Json.Decode.list (decodePartner partnershipTagInt))
+
+
+singlePartnerDecoder : Int -> Json.Decode.Decoder Partner
+singlePartnerDecoder partnershipTagInt =
+    Json.Decode.at [ "data", "partner" ] (decodePartner partnershipTagInt)
 
 
 decodePartner : Int -> Json.Decode.Decoder Partner

--- a/src/Theme/Page/Index.elm
+++ b/src/Theme/Page/Index.elm
@@ -5,10 +5,10 @@ import Copy.Text exposing (t)
 import Css exposing (Style, absolute, after, auto, backgroundImage, backgroundPosition, backgroundRepeat, backgroundSize, batch, before, block, borderRadius, bottom, calc, center, color, display, em, fontSize, fontStyle, fontWeight, height, important, inlineBlock, int, italic, lineHeight, margin2, marginBottom, marginLeft, marginRight, marginTop, maxWidth, minus, noRepeat, none, padding2, padding4, paddingBottom, paddingLeft, paddingRight, paddingTop, pct, position, property, px, relative, rem, textAlign, top, url, vw, width, zIndex)
 import Data.PlaceCal.Articles
 import Data.PlaceCal.Events
+import Data.PlaceCal.Partners
 import Helpers.TransRoutes
 import Html.Styled exposing (Html, a, div, h1, h2, img, p, section, text)
 import Html.Styled.Attributes exposing (alt, css, href, src)
-import Shared
 import Theme.Global
 import Theme.Page.Events
 import Theme.Page.News
@@ -18,7 +18,11 @@ import Time
 
 
 view :
-    Shared.Data
+    { events : List Data.PlaceCal.Events.Event
+    , partners : List Data.PlaceCal.Partners.Partner
+    , articles : List Data.PlaceCal.Articles.Article
+    , time : Time.Posix
+    }
     ->
         { localModel
             | filterByRegion : Int


### PR DESCRIPTION
Closes #482. 

Currently, the build time is taking a long time (~15 min on my machine). This is mainly because the request that fetches events occurs when building all pages. We have a cache that is used after the first request, but even so, the number of requests makes the process as a whole very slow.

This PR applies two changes that seem to improve the build performance significantly:

In the task that makes the request, it replaces all synchronous methods with asynchronous versions to avoid blocking the Event Loop (as suggested by the Perfomance section [here](https://package.elm-lang.org/packages/dillonkearns/elm-pages/latest/BackendTask.Custom)) and allow multiple tasks to be executed in parallel. (This change alone saved about 3 minutes locally.)

It removes the list of events from Shared.Data and starts making requests in the data function of each specific route that needs to access events. In the Event_ routes, I used a new task that specifically fetches that event. Interestingly, this change led to a much smaller number of requests, saving another 7–8 minutes of the build process.

This is surprising because I initially thought that the tasks in the data function of Shared were executed only once, but while debugging I noticed that in fact these tasks were running every time a new route was created in the build process. This means that the Articles and Partners tasks that are still in Shared exhibit the same behavior. However, since we already have a significant improvement and it didn’t seem as straightforward to move these requests as I did with the events, I thought it would be worth delivering what is already done.

Finally, about the annoying logs (#449), they happen precisely because the same task is running unnecessarily multiple times. I believe that if we removed all tasks from Shared, they would disappear completely. In the meantime, I disabled these logs using BackendTask.quiet in both custom tasks.