### PR TITLE
Go to next event

### DIFF
--- a/app/Route/Events.elm
+++ b/app/Route/Events.elm
@@ -140,6 +140,9 @@ update app _ msg model =
                     , Just (SetRegion tagId)
                     )
 
+        Theme.Page.Events.ClickedGoToNextEvent nextEventTime ->
+            ( { model | filterByDate = Theme.Paginator.Day nextEventTime }, Effect.none, Nothing )
+
 
 subscriptions : RouteParams -> UrlPath.UrlPath -> Shared.Model -> Model -> Sub Msg
 subscriptions _ _ _ _ =

--- a/app/Route/Index.elm
+++ b/app/Route/Index.elm
@@ -24,6 +24,7 @@ import Time
 import UrlPath
 import View
 import Messages exposing (Msg(..))
+import Theme.Page.Events exposing (Msg(..))
 
 
 type alias Model =
@@ -33,7 +34,7 @@ type alias Model =
 
 
 type alias Msg =
-    Theme.RegionSelector.Msg
+    Theme.Page.Events.Msg
 
 
 type alias RouteParams =
@@ -60,13 +61,16 @@ update :
     -> ( Model, Effect.Effect Msg, Maybe Shared.Msg )
 update app _ msg model =
     case msg of
-        ClickedSelector tagId ->
-            ( { model
-                | filterByRegion = tagId
-              }
-            , Effect.none
-            , Just (SetRegion tagId)
-            )
+        RegionSelectorMsg submsg ->
+            case submsg of
+                ClickedSelector tagId ->
+                    ( { model
+                        | filterByRegion = tagId
+                    }
+                    , Effect.none
+                    , Just (SetRegion tagId)
+                    )
+        _ -> ( model, Effect.none, Nothing )
 
 
 subscriptions : RouteParams -> UrlPath.UrlPath -> Shared.Model -> Model -> Sub Msg

--- a/app/Route/Partners/Partner_.elm
+++ b/app/Route/Partners/Partner_.elm
@@ -175,6 +175,9 @@ update app _ msg model =
             -- We do not include Region Selector on individual Partner pages
             -- But may  in future if some partners have events in multiple regions
             ( model, Effect.none )
+        
+        Theme.Page.Events.ClickedGoToNextEvent nextEventTime ->
+            ( { model | filterByDate = Theme.Paginator.Day nextEventTime }, Effect.none )
 
 
 subscriptions : RouteParams -> UrlPath.UrlPath -> Shared.Model -> Model -> Sub Msg

--- a/src/Copy/Keys.elm
+++ b/src/Copy/Keys.elm
@@ -74,6 +74,7 @@ type Key
     | EventsFilterLabelTomorrow
     | EventsFilterLabelAllPast
     | EventsFilterLabelAllFuture
+    | GoToNextEvent
       --- Event Page
     | EventTitle Prefix String
     | EventMetaDescription String

--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -187,7 +187,7 @@ t key =
             "There are no upcoming events. Check back for updates!"
 
         EventsEmptyText ->
-            "There are no upcoming events on this date. Check back for updates!"
+            "There are no upcoming events on this date."
 
         PreviousEventsEmptyTextAll ->
             "There have been no events in the recent past."
@@ -204,6 +204,9 @@ t key =
         EventsFilterLabelAllFuture ->
             "Future events"
 
+        GoToNextEvent ->
+            "Go to next event"
+        
         --- Event Page
         EventTitle prefix eventName ->
             case prefix of

--- a/src/Data/PlaceCal/Events.elm
+++ b/src/Data/PlaceCal/Events.elm
@@ -1,4 +1,4 @@
-module Data.PlaceCal.Events exposing (Event, EventPartner, afterDate, eventFromSlug, eventPartnerFromId, eventsData, eventsFromRegionId, eventsOnDate, eventsWithPartners, nextNEvents, onOrBeforeDate)
+module Data.PlaceCal.Events exposing (Event, EventPartner, afterDate, eventFromSlug, eventPartnerFromId, eventsData, eventsFromRegionId, eventsOnDate, eventsWithPartners, nextNEvents, onOrBeforeDate, nextEventStartTime)
 
 import BackendTask
 import BackendTask.Custom
@@ -151,6 +151,14 @@ eventsWithPartners eventList partnerList =
     List.map
         (\event -> { event | partner = eventPartnerFromId partnerList event.partner.id })
         eventList
+
+nextEventStartTime : List Event -> Int -> Time.Posix -> Maybe Time.Posix
+nextEventStartTime eventList tagId nowTime =
+    eventsFromRegionId (afterDate eventList nowTime) tagId
+    |> List.map (\event -> Time.posixToMillis event.startDatetime)
+    |> List.sort
+    |> List.head
+    |> Maybe.map Time.millisToPosix
 
 
 

--- a/src/Theme/Page/Index.elm
+++ b/src/Theme/Page/Index.elm
@@ -15,6 +15,8 @@ import Theme.Page.News
 import Theme.Paginator
 import Theme.RegionSelector
 import Time
+import Theme.Page.Events exposing (fromRegionSelectorMsg)
+import Theme.Page.Events exposing (Msg)
 
 
 view :
@@ -24,7 +26,7 @@ view :
             | filterByRegion : Int
             , nowTime : Time.Posix
         }
-    -> Html Theme.RegionSelector.Msg
+    -> Html Theme.Page.Events.Msg
 view sharedData localModel =
     div [ css [ pageWrapperStyle ] ]
         [ viewIntro (t IndexIntroTitle) (t IndexIntroMessage) (t IndexIntroButtonText)
@@ -56,11 +58,11 @@ viewIntro introTitle introMsg eventButtonText =
         ]
 
 
-viewFeatured : Time.Posix -> List Data.PlaceCal.Events.Event -> Int -> Html Theme.RegionSelector.Msg
+viewFeatured : Time.Posix -> List Data.PlaceCal.Events.Event -> Int -> Html Msg
 viewFeatured fromTime eventList regionId =
     section [ css [ sectionStyle, Theme.Global.darkBlueBackgroundStyle, eventsSectionStyle ] ]
         [ h2 [ css [ Theme.Global.smallFloatingTitleStyle ] ] [ text (t IndexFeaturedHeader) ]
-        , Theme.RegionSelector.viewRegionSelector { filterBy = regionId }
+        , Theme.RegionSelector.viewRegionSelector { filterBy = regionId } |> Html.Styled.map fromRegionSelectorMsg
         , Theme.Page.Events.viewEventsList { filterByDate = Theme.Paginator.Future, filterByRegion = regionId, nowTime = fromTime } eventList (Just 8)
         , p [ css [ Theme.Global.buttonFloatingWrapperStyle, width (calc (pct 100) minus (rem 2)) ] ]
             [ a

--- a/src/Theme/Paginator.elm
+++ b/src/Theme/Paginator.elm
@@ -1,4 +1,4 @@
-module Theme.Paginator exposing (Filter(..), Msg(..), ScrollDirection(..), filterEvents, scrollPagination, viewPagination)
+module Theme.Paginator exposing (Filter(..), Msg(..), ScrollDirection(..), filterEvents, scrollPagination, viewPagination, paginationButtonStyle, buttonWidthFullWidth, buttonWidthMobile, buttonWidthTablet)
 
 import Browser.Dom exposing (Error, Viewport, getViewportOf, setViewportOf)
 import Copy.Keys exposing (Key(..))


### PR DESCRIPTION
Fixes #467 

## Description
- Adds button to skip to next event if there are no events for the selected filter.

Tested on both Event and Partner pages:

https://github.com/user-attachments/assets/a4e333d1-9c59-4fc0-909c-c64c38b2dae6
