### PR TITLE
Increase cron frequency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 on:
   schedule:
-    - cron: "0 08,11,14,17,20 * * *"
+    - cron: "0 * * * *"
 
 jobs:
   build:


### PR DESCRIPTION
Builds are now sub 5 minutes thanks to the great work by @mateusfpleite so propose we increase this as currently it can be a very long delay between PlaceCal update and the info going live.

It looks like the previous limit was removed entirely also but might be set to 3,000 minutes in the future.

If this works let's reduce it to every 30 mins.

https://developers.cloudflare.com/workers/ci-cd/builds/limits-and-pricing/