### PR TITLE
fix: Only show region selector for sites with more than one partnership

### DIFF
--- a/src/Theme/Page/Events.elm
+++ b/src/Theme/Page/Events.elm
@@ -44,17 +44,15 @@ viewEvents :
         }
     -> Html Msg
 viewEvents eventsList model =
-    section [ css [ eventsContainerStyle ] ] <|
-        if List.length Data.PlaceCal.Partners.partnershipTagList > 1 then
-            [ Theme.RegionSelector.viewRegionSelector { filterBy = model.filterByRegion } |> Html.Styled.map fromRegionSelectorMsg
-            , Theme.Paginator.viewPagination model |> Html.Styled.map fromPaginatorMsg
-            , viewEventsList model eventsList Nothing
-            ]
+    section [ css [ eventsContainerStyle ] ]
+        [ if List.length Data.PlaceCal.Partners.partnershipTagList > 1 then
+            Theme.RegionSelector.viewRegionSelector { filterBy = model.filterByRegion } |> Html.Styled.map fromRegionSelectorMsg
 
-        else
-            [ Theme.Paginator.viewPagination model |> Html.Styled.map fromPaginatorMsg
-            , viewEventsList model eventsList Nothing
-            ]
+          else
+            text ""
+        , Theme.Paginator.viewPagination model |> Html.Styled.map fromPaginatorMsg
+        , viewEventsList model eventsList Nothing
+        ]
 
 
 viewEventsList :

--- a/src/Theme/Page/Events.elm
+++ b/src/Theme/Page/Events.elm
@@ -6,6 +6,7 @@ import Css exposing (Style, alignItems, backgroundColor, batch, block, borderBot
 import Css.Global exposing (descendants, typeSelector)
 import Css.Transitions exposing (transition)
 import Data.PlaceCal.Events
+import Data.PlaceCal.Partners
 import Helpers.TransDate as TransDate
 import Helpers.TransRoutes as TransRoutes exposing (Route(..))
 import Html.Styled exposing (Html, a, article, button, div, h4, li, p, section, span, text, time, ul)
@@ -43,11 +44,17 @@ viewEvents :
         }
     -> Html Msg
 viewEvents eventsList model =
-    section [ css [ eventsContainerStyle ] ]
-        [ Theme.RegionSelector.viewRegionSelector { filterBy = model.filterByRegion } |> Html.Styled.map fromRegionSelectorMsg
-        , Theme.Paginator.viewPagination model |> Html.Styled.map fromPaginatorMsg
-        , viewEventsList model eventsList Nothing
-        ]
+    section [ css [ eventsContainerStyle ] ] <|
+        if List.length Data.PlaceCal.Partners.partnershipTagList > 1 then
+            [ Theme.RegionSelector.viewRegionSelector { filterBy = model.filterByRegion } |> Html.Styled.map fromRegionSelectorMsg
+            , Theme.Paginator.viewPagination model |> Html.Styled.map fromPaginatorMsg
+            , viewEventsList model eventsList Nothing
+            ]
+
+        else
+            [ Theme.Paginator.viewPagination model |> Html.Styled.map fromPaginatorMsg
+            , viewEventsList model eventsList Nothing
+            ]
 
 
 viewEventsList :

--- a/src/Theme/Page/Index.elm
+++ b/src/Theme/Page/Index.elm
@@ -62,17 +62,29 @@ viewIntro introTitle introMsg eventButtonText =
 
 viewFeatured : Time.Posix -> List Data.PlaceCal.Events.Event -> Int -> Html Msg
 viewFeatured fromTime eventList regionId =
-    section [ css [ sectionStyle, Theme.Global.darkBlueBackgroundStyle, eventsSectionStyle ] ]
-        [ h2 [ css [ Theme.Global.smallFloatingTitleStyle ] ] [ text (t IndexFeaturedHeader) ]
-        , Theme.RegionSelector.viewRegionSelector { filterBy = regionId } |> Html.Styled.map fromRegionSelectorMsg
-        , Theme.Page.Events.viewEventsList { filterByDate = Theme.Paginator.Future, filterByRegion = regionId, nowTime = fromTime } eventList (Just 8)
-        , p [ css [ Theme.Global.buttonFloatingWrapperStyle, width (calc (pct 100) minus (rem 2)) ] ]
-            [ a
-                [ href (Helpers.TransRoutes.toAbsoluteUrl Helpers.TransRoutes.Events)
-                , css [ Theme.Global.pinkButtonOnDarkBackgroundStyle ]
-                ]
-                [ text (t IndexFeaturedButtonText) ]
+    section [ css [ sectionStyle, Theme.Global.darkBlueBackgroundStyle, eventsSectionStyle ] ] <|
+        if List.length Data.PlaceCal.Partners.partnershipTagList > 1 then
+            [ h2 [ css [ Theme.Global.smallFloatingTitleStyle ] ] [ text (t IndexFeaturedHeader) ]
+            , Theme.RegionSelector.viewRegionSelector { filterBy = regionId } |> Html.Styled.map fromRegionSelectorMsg
+            , Theme.Page.Events.viewEventsList { filterByDate = Theme.Paginator.Future, filterByRegion = regionId, nowTime = fromTime } eventList (Just 8)
+            , viewAllEventsButton
             ]
+
+        else
+            [ h2 [ css [ Theme.Global.smallFloatingTitleStyle ] ] [ text (t IndexFeaturedHeader) ]
+            , Theme.Page.Events.viewEventsList { filterByDate = Theme.Paginator.Future, filterByRegion = regionId, nowTime = fromTime } eventList (Just 8)
+            , viewAllEventsButton
+            ]
+
+
+viewAllEventsButton : Html msg
+viewAllEventsButton =
+    p [ css [ Theme.Global.buttonFloatingWrapperStyle, width (calc (pct 100) minus (rem 2)) ] ]
+        [ a
+            [ href (Helpers.TransRoutes.toAbsoluteUrl Helpers.TransRoutes.Events)
+            , css [ Theme.Global.pinkButtonOnDarkBackgroundStyle ]
+            ]
+            [ text (t IndexFeaturedButtonText) ]
         ]
 
 

--- a/src/Theme/Page/Index.elm
+++ b/src/Theme/Page/Index.elm
@@ -62,19 +62,16 @@ viewIntro introTitle introMsg eventButtonText =
 
 viewFeatured : Time.Posix -> List Data.PlaceCal.Events.Event -> Int -> Html Msg
 viewFeatured fromTime eventList regionId =
-    section [ css [ sectionStyle, Theme.Global.darkBlueBackgroundStyle, eventsSectionStyle ] ] <|
-        if List.length Data.PlaceCal.Partners.partnershipTagList > 1 then
-            [ h2 [ css [ Theme.Global.smallFloatingTitleStyle ] ] [ text (t IndexFeaturedHeader) ]
-            , Theme.RegionSelector.viewRegionSelector { filterBy = regionId } |> Html.Styled.map fromRegionSelectorMsg
-            , Theme.Page.Events.viewEventsList { filterByDate = Theme.Paginator.Future, filterByRegion = regionId, nowTime = fromTime } eventList (Just 8)
-            , viewAllEventsButton
-            ]
+    section [ css [ sectionStyle, Theme.Global.darkBlueBackgroundStyle, eventsSectionStyle ] ]
+        [ h2 [ css [ Theme.Global.smallFloatingTitleStyle ] ] [ text (t IndexFeaturedHeader) ]
+        , if List.length Data.PlaceCal.Partners.partnershipTagList > 1 then
+            Theme.RegionSelector.viewRegionSelector { filterBy = regionId } |> Html.Styled.map fromRegionSelectorMsg
 
-        else
-            [ h2 [ css [ Theme.Global.smallFloatingTitleStyle ] ] [ text (t IndexFeaturedHeader) ]
-            , Theme.Page.Events.viewEventsList { filterByDate = Theme.Paginator.Future, filterByRegion = regionId, nowTime = fromTime } eventList (Just 8)
-            , viewAllEventsButton
-            ]
+          else
+            text ""
+        , Theme.Page.Events.viewEventsList { filterByDate = Theme.Paginator.Future, filterByRegion = regionId, nowTime = fromTime } eventList (Just 8)
+        , viewAllEventsButton
+        ]
 
 
 viewAllEventsButton : Html msg

--- a/src/Theme/Page/Partners.elm
+++ b/src/Theme/Page/Partners.elm
@@ -22,19 +22,16 @@ viewPartners partnerList model =
         filteredPartnerList =
             Data.PlaceCal.Partners.partnersFromRegionId partnerList model.filterByRegion
     in
-    section [] <|
-        if List.length Data.PlaceCal.Partners.partnershipTagList > 1 then
-            [ h3 [ css [ partnersListTitleStyle ] ] [ text (t PartnersListHeading) ]
-            , Theme.RegionSelector.viewRegionSelector { filterBy = model.filterByRegion }
-            , viewPartnerList filteredPartnerList
-            , viewMap filteredPartnerList
-            ]
+    section []
+        [ h3 [ css [ partnersListTitleStyle ] ] [ text (t PartnersListHeading) ]
+        , if List.length Data.PlaceCal.Partners.partnershipTagList > 1 then
+            Theme.RegionSelector.viewRegionSelector { filterBy = model.filterByRegion }
 
-        else
-            [ h3 [ css [ partnersListTitleStyle ] ] [ text (t PartnersListHeading) ]
-            , viewPartnerList filteredPartnerList
-            , viewMap filteredPartnerList
-            ]
+          else
+            text ""
+        , viewPartnerList filteredPartnerList
+        , viewMap filteredPartnerList
+        ]
 
 
 viewPartnerList : List Data.PlaceCal.Partners.Partner -> Html msg

--- a/src/Theme/Page/Partners.elm
+++ b/src/Theme/Page/Partners.elm
@@ -22,16 +22,28 @@ viewPartners partnerList model =
         filteredPartnerList =
             Data.PlaceCal.Partners.partnersFromRegionId partnerList model.filterByRegion
     in
-    section []
-        [ h3 [ css [ partnersListTitleStyle ] ] [ text (t PartnersListHeading) ]
-        , Theme.RegionSelector.viewRegionSelector { filterBy = model.filterByRegion }
-        , if List.length filteredPartnerList > 0 then
-            ul [ css [ listStyle ] ] (List.map (\partner -> viewPartner partner) filteredPartnerList)
+    section [] <|
+        if List.length Data.PlaceCal.Partners.partnershipTagList > 1 then
+            [ h3 [ css [ partnersListTitleStyle ] ] [ text (t PartnersListHeading) ]
+            , Theme.RegionSelector.viewRegionSelector { filterBy = model.filterByRegion }
+            , viewPartnerList filteredPartnerList
+            , viewMap filteredPartnerList
+            ]
 
-          else
-            p [] [ text (t PartnersListEmpty) ]
-        , viewMap filteredPartnerList
-        ]
+        else
+            [ h3 [ css [ partnersListTitleStyle ] ] [ text (t PartnersListHeading) ]
+            , viewPartnerList filteredPartnerList
+            , viewMap filteredPartnerList
+            ]
+
+
+viewPartnerList : List Data.PlaceCal.Partners.Partner -> Html msg
+viewPartnerList partners =
+    if List.length partners > 0 then
+        ul [ css [ listStyle ] ] (List.map (\partner -> viewPartner partner) partners)
+
+    else
+        p [] [ text (t PartnersListEmpty) ]
 
 
 viewPartner : Data.PlaceCal.Partners.Partner -> Html msg

--- a/src/Theme/RegionSelector.elm
+++ b/src/Theme/RegionSelector.elm
@@ -2,10 +2,10 @@ module Theme.RegionSelector exposing (Msg(..), viewRegionSelector)
 
 import Copy.Keys exposing (Key(..))
 import Copy.Text exposing (t)
-import Css exposing (Style, active, auto, backgroundColor, batch, borderBox, borderColor, borderRadius, borderStyle, borderWidth, boxSizing, center, color, cursor, displayFlex, fitContent, flexWrap, focus, fontSize, fontWeight, hover, int, justifyContent, listStyleType, margin2, margin4, maxWidth, none, padding4, pointer, position, property, px, relative, rem, solid, textAlign, width, wrap)
+import Css exposing (Style, active, auto, backgroundColor, batch, borderBox, borderColor, borderRadius, borderStyle, borderWidth, boxSizing, center, color, cursor, display, displayFlex, fitContent, flexWrap, focus, fontSize, fontWeight, hover, int, justifyContent, listStyleType, margin2, margin4, maxWidth, none, padding4, pointer, position, property, px, relative, rem, solid, textAlign, width, wrap)
 import Css.Global exposing (descendants, typeSelector)
 import Css.Transitions exposing (transition)
-import Data.PlaceCal.Partners
+import Data.PlaceCal.Partners exposing (partnershipTagList)
 import Html.Styled exposing (Html, button, div, li, text, ul)
 import Html.Styled.Attributes exposing (css)
 import Html.Styled.Events
@@ -95,11 +95,15 @@ buttonMarginFullWidth =
 
 regionSelectorWrapper : Style
 regionSelectorWrapper =
-    batch
-        [ margin2 (rem 0) (rem -0.5)
-        , withMediaSmallDesktopUp [ margin4 (rem 2) (rem -1) (rem 3) (rem -1) ]
-        , withMediaTabletLandscapeUp [ margin2 (rem 2) (rem -1) ]
-        ]
+    if List.length partnershipTagList > 1 then
+        batch
+            [ margin2 (rem 0) (rem -0.5)
+            , withMediaSmallDesktopUp [ margin4 (rem 2) (rem -1) (rem 3) (rem -1) ]
+            , withMediaTabletLandscapeUp [ margin2 (rem 2) (rem -1) ]
+            ]
+
+    else
+        display none
 
 
 regionSelectorContainer : Style

--- a/src/Theme/RegionSelector.elm
+++ b/src/Theme/RegionSelector.elm
@@ -95,15 +95,11 @@ buttonMarginFullWidth =
 
 regionSelectorWrapper : Style
 regionSelectorWrapper =
-    if List.length partnershipTagList > 1 then
-        batch
-            [ margin2 (rem 0) (rem -0.5)
-            , withMediaSmallDesktopUp [ margin4 (rem 2) (rem -1) (rem 3) (rem -1) ]
-            , withMediaTabletLandscapeUp [ margin2 (rem 2) (rem -1) ]
-            ]
-
-    else
-        display none
+    batch
+        [ margin2 (rem 0) (rem -0.5)
+        , withMediaSmallDesktopUp [ margin4 (rem 2) (rem -1) (rem 3) (rem -1) ]
+        , withMediaTabletLandscapeUp [ margin2 (rem 2) (rem -1) ]
+        ]
 
 
 regionSelectorContainer : Style

--- a/src/Theme/RegionSelector.elm
+++ b/src/Theme/RegionSelector.elm
@@ -2,7 +2,7 @@ module Theme.RegionSelector exposing (Msg(..), viewRegionSelector)
 
 import Copy.Keys exposing (Key(..))
 import Copy.Text exposing (t)
-import Css exposing (Style, active, auto, backgroundColor, batch, borderBox, borderColor, borderRadius, borderStyle, borderWidth, boxSizing, center, color, cursor, display, displayFlex, fitContent, flexWrap, focus, fontSize, fontWeight, hover, int, justifyContent, listStyleType, margin2, margin4, maxWidth, none, padding4, pointer, position, property, px, relative, rem, solid, textAlign, width, wrap)
+import Css exposing (Style, active, auto, backgroundColor, batch, borderBox, borderColor, borderRadius, borderStyle, borderWidth, boxSizing, center, color, cursor, displayFlex, fitContent, flexWrap, focus, fontSize, fontWeight, hover, int, justifyContent, listStyleType, margin2, margin4, maxWidth, none, padding4, pointer, position, property, px, relative, rem, solid, textAlign, width, wrap)
 import Css.Global exposing (descendants, typeSelector)
 import Css.Transitions exposing (transition)
 import Data.PlaceCal.Partners exposing (partnershipTagList)

--- a/src/Theme/RegionSelector.elm
+++ b/src/Theme/RegionSelector.elm
@@ -5,7 +5,7 @@ import Copy.Text exposing (t)
 import Css exposing (Style, active, auto, backgroundColor, batch, borderBox, borderColor, borderRadius, borderStyle, borderWidth, boxSizing, center, color, cursor, displayFlex, fitContent, flexWrap, focus, fontSize, fontWeight, hover, int, justifyContent, listStyleType, margin2, margin4, maxWidth, none, padding4, pointer, position, property, px, relative, rem, solid, textAlign, width, wrap)
 import Css.Global exposing (descendants, typeSelector)
 import Css.Transitions exposing (transition)
-import Data.PlaceCal.Partners exposing (partnershipTagList)
+import Data.PlaceCal.Partners
 import Html.Styled exposing (Html, button, div, li, text, ul)
 import Html.Styled.Attributes exposing (css)
 import Html.Styled.Events


### PR DESCRIPTION
Fixes #507

## Description

- Shows region selector for sites with more than one partnership, hides otherwise

Tested using `PARTNERSHIP_TAG_LIST=3|London`:

![Screenshot 2025-01-28 at 14 56 41](https://github.com/user-attachments/assets/3937f924-f133-4666-8fc5-87d7a5c5d58c)

![Screenshot 2025-01-28 at 14 56 53](https://github.com/user-attachments/assets/3f558145-267c-4cb8-af0d-dc9c48a86442)